### PR TITLE
[ADD] 8.0 take into account HTTP response error codes

### DIFF
--- a/.travis_push_doc
+++ b/.travis_push_doc
@@ -2,24 +2,25 @@
 
 set -o errexit -o nounset
 
-if [ $TRAVIS_BRANCH = "8.0" ] && [ $TRAVIS_PULL_REQUEST = false ]; then
-  cd ${TRAVIS_BUILD_DIR}
+if [ "$TRAVIS_BRANCH" = "8.0" ] && [ "$TRAVIS_PULL_REQUEST" = false ]; then
+  cd "${TRAVIS_BUILD_DIR}"
   rev=$(git rev-parse --short HEAD)
 
-  cd ${HOME}/doc
+  mkdir gh-pages
+  cd gh-pages
+
   git init
   git config user.name "Guewen Baconnier"
   git config user.email "guewen.baconnier@camptocamp.com"
-  git remote add upstream https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+  git remote add upstream "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git"
   git fetch upstream
-  git reset upstream/gh-pages
+  git checkout gh-pages
 
-  echo "odoo-connector.com" > CNAME
-  touch .nojekyll
+  rm -rf "${TRAVIS_BRANCH}"
+  mv ../doc "${TRAVIS_BRANCH}"
 
-  touch .
-  git add -A .
-  git commit -m"rebuild pages at ${rev}"
+  git add "${TRAVIS_BRANCH}"
+  git commit -m"rebuild pages at ${rev} on branch ${TRAVIS_BRANCH}"
 
   git push -q upstream HEAD:gh-pages
 fi

--- a/.travis_push_doc
+++ b/.travis_push_doc
@@ -17,7 +17,7 @@ if [ "$TRAVIS_BRANCH" = "8.0" ] && [ "$TRAVIS_PULL_REQUEST" = false ]; then
   git checkout gh-pages
 
   rm -rf "${TRAVIS_BRANCH}"
-  mv ../doc "${TRAVIS_BRANCH}"
+  mv "${HOME}/doc" "${TRAVIS_BRANCH}"
 
   git add "${TRAVIS_BRANCH}"
   git commit -m"rebuild pages at ${rev} on branch ${TRAVIS_BRANCH}"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Documentation:
 http://www.odoo-connector.com
 
 [//]: # (addons)
+
 Available addons
 ----------------
 addon | version | summary

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ addon | version | summary
 --- | --- | ---
 [connector](connector/) | 8.0.3.3.0 | Connector
 [connector_base_product](connector_base_product/) | 8.0.1.0.0 | Connector Base Product
+[connector_job_subscribe](connector_job_subscribe/) | 8.0.1.0.0 | Connector
 
 [//]: # (end addons)
 

--- a/connector/connector.py
+++ b/connector/connector.py
@@ -379,6 +379,7 @@ class ConnectorEnvironment(object):
         else:
             return cls(backend_record, session, model)
 
+
 Environment = DeprecatedClass('Environment',
                               ConnectorEnvironment)
 

--- a/connector/doc/_templates/navbar.html
+++ b/connector/doc/_templates/navbar.html
@@ -10,8 +10,21 @@
     <ul class="dropdown-menu"
         role="menu"
         aria-labelledby="dLabelTranslations">
-      <li><a class="reference" href="http://odoo-connector.com">English</a><li>
-      <li><a class="reference" href="http://odoo-connector.com/fr">French</a><li>
+      <li><a class="reference" href="http://odoo-connector.com/8.0">English</a><li>
+      <li><a class="reference" href="http://odoo-connector.com/8.0/fr">French</a><li>
+    </ul>
+  </li>
+  <li class="dropdown">
+    <a role="button"
+       id="dLabelVersions"
+       data-toggle="dropdown"
+       data-target="#"
+       href="#">Version<b class="caret"></b></a>
+    <ul class="dropdown-menu"
+        role="menu"
+        aria-labelledby="dLabeVersions">
+      <li><a class="reference" href="http://odoo-connector.com/9.0">9.0</a><li>
+      <li><a class="reference" href="http://odoo-connector.com/">10.0</a><li>
     </ul>
   </li>
   {{ super() }}

--- a/connector/i18n/am.po
+++ b/connector/i18n/am.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:26+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Amharic (http://www.transifex.com/oca/OCA-connector-8-0/language/am/)\n"
 "MIME-Version: 1.0\n"
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "o"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/ar.po
+++ b/connector/i18n/ar.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-23 08:40+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:39+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Arabic (http://www.transifex.com/oca/OCA-connector-8-0/language/ar/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "الشركة"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "الحالة"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/ar.po
+++ b/connector/i18n/ar.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-23 08:40+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Arabic (http://www.transifex.com/oca/OCA-connector-8-0/language/ar/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "مهمة"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/ar.po
+++ b/connector/i18n/ar.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:24+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Arabic (http://www.transifex.com/oca/OCA-connector-8-0/language/ar/)\n"
 "MIME-Version: 1.0\n"
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr ""
+msgstr "القناة"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "قنوات"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "أنشئ بواسطة"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "أنشئ في"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "تاريخ آخر رسالة في هذا السجل."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "الوصف"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr ""
+msgstr "اسم العرض"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr ""
+msgstr "المتابعون"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "تجميع حسب"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "المعرف"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr ""
+msgstr "إذا حددته، ستتطلب الرسائل الجديدة انتباهك"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "تاريخ آخر رسالة"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr ""
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "آخر تعديل في"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "آخر تحديث بواسطة"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "آخر تحديث في"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr ""
+msgstr "الرسائل"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr ""
+msgstr "الرسائل و سجل التواصل"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "الاسم"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -577,7 +577,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
 msgid "Related"
-msgstr ""
+msgstr "مقترن"
 
 #. module: connector
 #: code:addons/connector/related_action.py:48
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr ""
+msgstr "رسائل غير مقروءة"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "أو"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/ar.po
+++ b/connector/i18n/ar.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-01 01:36+0000\n"
-"PO-Revision-Date: 2017-08-11 11:55+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:22+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Arabic (http://www.transifex.com/oca/OCA-connector-8-0/language/ar/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "نشِط"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/ar.po
+++ b/connector/i18n/ar.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:39+0000\n"
+"POT-Creation-Date: 2017-07-01 01:36+0000\n"
+"PO-Revision-Date: 2017-08-11 11:55+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Arabic (http://www.transifex.com/oca/OCA-connector-8-0/language/ar/)\n"
 "MIME-Version: 1.0\n"
@@ -483,7 +483,7 @@ msgstr "الرسائل و سجل التواصل"
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr ""
+msgstr "النموذج"
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0

--- a/connector/i18n/bs.po
+++ b/connector/i18n/bs.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-11-22 16:24+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Bosnian (http://www.transifex.com/oca/OCA-connector-8-0/language/bs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: bs\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr "Otkaži"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Kanal"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Kanali"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Kreirao"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Kreirano"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Datum posljednje poruke ostavljene na unos."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Opis"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Prikaži naziv"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Pratioci"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Grupiši po"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Ako je označeno nove poruke će zahtjevati vašu pažnju."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Datum zadnje poruke"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Zadnje mijenjano"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Zadnji ažurirao"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Zadnje ažurirano"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Poruke"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Poruke i istorija komunikacije"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Ime"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Nepročitane poruke"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "ili"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/bs.po
+++ b/connector/i18n/bs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 11:09+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:24+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Bosnian (http://www.transifex.com/oca/OCA-connector-8-0/language/bs/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Aktivno"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/bs.po
+++ b/connector/i18n/bs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-22 16:24+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 11:09+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Bosnian (http://www.transifex.com/oca/OCA-connector-8-0/language/bs/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Kompanija"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/ca.po
+++ b/connector/i18n/ca.po
@@ -4,13 +4,13 @@
 # 
 # Translators:
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2014
-# llum.birque@gmail.com <llum.birque@gmail.com>, 2015
+# llum.birque@gmail.com <inactive+Quim@transifex.com>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-11 01:37+0000\n"
-"PO-Revision-Date: 2017-03-24 09:00+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:40+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Catalan (http://www.transifex.com/oca/OCA-connector-8-0/language/ca/)\n"
 "MIME-Version: 1.0\n"
@@ -98,13 +98,13 @@ msgid "Canceled. Nothing to do."
 msgstr "Cancel·lat, res a fer."
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr "El Canal principal no es pot modificar"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr "El canal principal no es pot esborrar"
@@ -526,7 +526,7 @@ msgid "Parent Channel"
 msgstr "Canal Pare"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr "Cal indicar Canal Pare"
@@ -650,7 +650,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr "Compartir o incrustar qualsevol pantalla de odoo"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/ca.po
+++ b/connector/i18n/ca.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-11 09:16+0000\n"
-"PO-Revision-Date: 2015-10-15 13:38+0000\n"
+"POT-Creation-Date: 2017-01-07 01:20+0000\n"
+"PO-Revision-Date: 2017-01-13 09:22+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Catalan (http://www.transifex.com/oca/OCA-connector-8-0/language/ca/)\n"
 "MIME-Version: 1.0\n"
@@ -251,6 +251,18 @@ msgid "Description"
 msgstr "Descripció"
 
 #. module: connector
+#: field:connector.backend,display_name:0
+#: field:connector.checkpoint,display_name:0
+#: field:connector.checkpoint.review,display_name:0
+#: field:connector.config.settings,display_name:0
+#: field:external.binding,display_name:0 field:queue.job,display_name:0
+#: field:queue.job.channel,display_name:0
+#: field:queue.job.function,display_name:0
+#: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
+msgid "Display Name"
+msgstr "Veure el nom"
+
+#. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
 msgstr "Fet"
@@ -411,6 +423,18 @@ msgid "Last Message Date"
 msgstr "Data darrer missatge"
 
 #. module: connector
+#: field:connector.backend,__last_update:0
+#: field:connector.checkpoint,__last_update:0
+#: field:connector.checkpoint.review,__last_update:0
+#: field:connector.config.settings,__last_update:0
+#: field:external.binding,__last_update:0 field:queue.job,__last_update:0
+#: field:queue.job.channel,__last_update:0
+#: field:queue.job.function,__last_update:0
+#: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
+msgid "Last Modified on"
+msgstr "Darrera modificació el"
+
+#. module: connector
 #: field:connector.checkpoint,write_uid:0
 #: field:connector.checkpoint.review,write_uid:0
 #: field:connector.config.settings,write_uid:0
@@ -468,6 +492,11 @@ msgstr "Model"
 #: field:queue.job.function,name:0
 msgid "Name"
 msgstr "Nom"
+
+#. module: connector
+#: help:connector.checkpoint,name:0
+msgid "Name of the record to review"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -533,9 +562,19 @@ msgid "Queue Worker"
 msgstr "Queue Worker"
 
 #. module: connector
+#: field:connector.checkpoint,record:0
+msgid "Record"
+msgstr ""
+
+#. module: connector
 #: field:connector.checkpoint,record_id:0
 msgid "Record ID"
 msgstr "ID Registre"
+
+#. module: connector
+#: field:connector.checkpoint,name:0
+msgid "Record Name"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -660,6 +699,11 @@ msgstr "La tasca fallarà si el nombre de intents supera el màxim permès,\nEls
 #: help:connector.checkpoint,backend_id:0
 msgid "The record has been imported from this backend"
 msgstr "El registre ha estat importat des d'aquest backend"
+
+#. module: connector
+#: help:connector.checkpoint,record:0
+msgid "The record to review."
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint.review:connector.view_connector_checkpoint_review

--- a/connector/i18n/ca.po
+++ b/connector/i18n/ca.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-07 01:20+0000\n"
-"PO-Revision-Date: 2017-01-13 09:22+0000\n"
+"POT-Creation-Date: 2017-03-11 01:37+0000\n"
+"PO-Revision-Date: 2017-03-24 09:00+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Catalan (http://www.transifex.com/oca/OCA-connector-8-0/language/ca/)\n"
 "MIME-Version: 1.0\n"
@@ -496,7 +496,7 @@ msgstr "Nom"
 #. module: connector
 #: help:connector.checkpoint,name:0
 msgid "Name of the record to review"
-msgstr ""
+msgstr "Nom del registre a revisar "
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -564,7 +564,7 @@ msgstr "Queue Worker"
 #. module: connector
 #: field:connector.checkpoint,record:0
 msgid "Record"
-msgstr ""
+msgstr "Registre"
 
 #. module: connector
 #: field:connector.checkpoint,record_id:0
@@ -574,7 +574,7 @@ msgstr "ID Registre"
 #. module: connector
 #: field:connector.checkpoint,name:0
 msgid "Record Name"
-msgstr ""
+msgstr "Nom del Registre "
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -703,7 +703,7 @@ msgstr "El registre ha estat importat des d'aquest backend"
 #. module: connector
 #: help:connector.checkpoint,record:0
 msgid "The record to review."
-msgstr ""
+msgstr "El registre per revisar. "
 
 #. module: connector
 #: view:connector.checkpoint.review:connector.view_connector_checkpoint_review

--- a/connector/i18n/ca_ES.po
+++ b/connector/i18n/ca_ES.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-22 16:25+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:41+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Catalan (Spain) (http://www.transifex.com/oca/OCA-connector-8-0/language/ca_ES/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Companyia"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Estat"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/ca_ES.po
+++ b/connector/i18n/ca_ES.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-11-22 16:25+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Catalan (Spain) (http://www.transifex.com/oca/OCA-connector-8-0/language/ca_ES/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
+"Language: ca_ES\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr "Cancel·la"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr ""
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr ""
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr ""
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/cs.po
+++ b/connector/i18n/cs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:55+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:39+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Czech (http://www.transifex.com/oca/OCA-connector-8-0/language/cs/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Společnost"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/cs.po
+++ b/connector/i18n/cs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:24+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:55+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Czech (http://www.transifex.com/oca/OCA-connector-8-0/language/cs/)\n"
 "MIME-Version: 1.0\n"
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr ""
+msgstr "Kanál"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Kanály"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "Vytvořil(a)"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "Vytvořeno"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "Datum posledního vzkazu u tohoto záznamu."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "Popis"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr ""
+msgstr "Zobrazovaný název"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr ""
+msgstr "Sledující"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "Seskupit podle"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr ""
+msgstr "Pokud je zaškrtnuto, nové zprávy vyžadují vaši pozornost."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "Datum posledního vzkazu"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr ""
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "Naposled upraveno"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "Naposled upraveno"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "Naposled upraveno"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr ""
+msgstr "Zprávy"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr ""
+msgstr "Zprávy a historie komunikace"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Název"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr ""
+msgstr "Nepřečtené zprávy"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "nebo"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/cs.po
+++ b/connector/i18n/cs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-01 01:36+0000\n"
-"PO-Revision-Date: 2017-08-11 11:55+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:22+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Czech (http://www.transifex.com/oca/OCA-connector-8-0/language/cs/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Aktivní"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/cs.po
+++ b/connector/i18n/cs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:39+0000\n"
+"POT-Creation-Date: 2017-07-01 01:36+0000\n"
+"PO-Revision-Date: 2017-08-11 11:55+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Czech (http://www.transifex.com/oca/OCA-connector-8-0/language/cs/)\n"
 "MIME-Version: 1.0\n"
@@ -668,7 +668,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr ""
+msgstr "Stav"
 
 #. module: connector
 #: field:connector.checkpoint,state:0

--- a/connector/i18n/da.po
+++ b/connector/i18n/da.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:44+0000\n"
+"POT-Creation-Date: 2017-07-01 01:36+0000\n"
+"PO-Revision-Date: 2017-08-11 11:56+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Danish (http://www.transifex.com/oca/OCA-connector-8-0/language/da/)\n"
 "MIME-Version: 1.0\n"
@@ -668,7 +668,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr ""
+msgstr "Delstat"
 
 #. module: connector
 #: field:connector.checkpoint,state:0

--- a/connector/i18n/da.po
+++ b/connector/i18n/da.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-19 12:45+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-22 14:08+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Danish (http://www.transifex.com/oca/OCA-connector-8-0/language/da/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Annuller"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/da.po
+++ b/connector/i18n/da.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-10-19 12:45+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Danish (http://www.transifex.com/oca/OCA-connector-8-0/language/da/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
+"Language: da\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr "Aktiv"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Kanal"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Kanaler"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Oprettet af"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Oprettet den"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Dato for sidste besked på denne post."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Beskrivelse"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Vist navn"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Followers"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Gruppér efter"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr "ID"
+msgstr "Id"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Hvis afmærket, kræver nye beskeder din attention"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Sidste dato for besked"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Sidst ændret den"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Sidst opdateret af"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Sidst opdateret den"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Beskeder"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Besked- og kommunikations historik"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Navn"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Ulæste beskeder"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "eller"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/da.po
+++ b/connector/i18n/da.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-22 14:08+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:44+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Danish (http://www.transifex.com/oca/OCA-connector-8-0/language/da/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Virksomhed"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/da_DK.po
+++ b/connector/i18n/da_DK.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-08-22 13:04+0000\n"
-"PO-Revision-Date: 2017-08-21 07:28+0000\n"
+"PO-Revision-Date: 2017-08-21 07:22+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Polish (http://www.transifex.com/oca/OCA-connector-8-0/language/pl/)\n"
+"Language-Team: Danish (Denmark) (http://www.transifex.com/oca/OCA-connector-8-0/language/da_DK/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: pl\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Language: da_DK\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Aktywny"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Anuluj"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Kanał"
+msgstr ""
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr "Kanały"
+msgstr ""
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Firma"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Utworzone przez"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Utworzone przez"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Utworzono"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Data ostatniej wiadomości w rekordzie."
+msgstr ""
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Opis"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,7 +258,7 @@ msgstr "Opis"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Wyświetlana nazwa "
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Obserwatorzy"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Pogrupuj wg"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Jeśli zaznaczone, to wiadomość wymaga twojej uwagi"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Data ostatniej wiadomości"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Data ostatniej wiadomości"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Ostatnio modyfikowano"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Ostatnio modyfikowano"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Ostatnio modyfikowane przez"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Ostatnio modyfikowane przez"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Ostatnia zmiana"
+msgstr ""
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Wiadomosći"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "Wiadomości i historia komunikacji"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Nazwa"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -577,7 +577,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
 msgid "Related"
-msgstr "Powiązane"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/related_action.py:48
@@ -668,7 +668,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr "Stan"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,state:0
@@ -679,12 +679,12 @@ msgstr ""
 #: field:connector.checkpoint,message_summary:0
 #: field:queue.job,message_summary:0
 msgid "Summary"
-msgstr ""
+msgstr "Oversigt"
 
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr "Zadanie"
+msgstr ""
 
 #. module: connector
 #: help:queue.job,max_retries:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Nieprzeczytane wiadomości"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "lub"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/de.po
+++ b/connector/i18n/de.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-11 01:37+0000\n"
-"PO-Revision-Date: 2017-03-19 12:09+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-19 11:44+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: German (http://www.transifex.com/oca/OCA-connector-8-0/language/de/)\n"
 "MIME-Version: 1.0\n"
@@ -99,13 +99,13 @@ msgid "Canceled. Nothing to do."
 msgstr "Storniert. Nicht zu tun."
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr "Kann den Hauptkanal nicht ändern"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr "Kann den Hauptkanal nicht entfernen"
@@ -527,7 +527,7 @@ msgid "Parent Channel"
 msgstr "Übergeordneter Kanal"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr "Übergeordneter Kanal erforderlich."
@@ -651,7 +651,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr "Teilen oder Einbetten eines jeden Bildschirms von Odoo."
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/de.po
+++ b/connector/i18n/de.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-04 09:43+0000\n"
+"POT-Creation-Date: 2017-03-11 01:37+0000\n"
+"PO-Revision-Date: 2017-03-19 12:09+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: German (http://www.transifex.com/oca/OCA-connector-8-0/language/de/)\n"
 "MIME-Version: 1.0\n"
@@ -565,7 +565,7 @@ msgstr "Warteschlangenarbeiter"
 #. module: connector
 #: field:connector.checkpoint,record:0
 msgid "Record"
-msgstr ""
+msgstr "Datensatz"
 
 #. module: connector
 #: field:connector.checkpoint,record_id:0

--- a/connector/i18n/el_GR.po
+++ b/connector/i18n/el_GR.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-22 16:30+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:39+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Greek (Greece) (http://www.transifex.com/oca/OCA-connector-8-0/language/el_GR/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Εταιρεία"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/el_GR.po
+++ b/connector/i18n/el_GR.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:26+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-22 16:30+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Greek (Greece) (http://www.transifex.com/oca/OCA-connector-8-0/language/el_GR/)\n"
 "MIME-Version: 1.0\n"
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr ""
+msgstr "Εφαρμογή"
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Άκυρο"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -246,7 +246,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "Περιγραφή"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Κατάσταση"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/el_GR.po
+++ b/connector/i18n/el_GR.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:39+0000\n"
+"POT-Creation-Date: 2017-07-01 01:36+0000\n"
+"PO-Revision-Date: 2017-08-11 11:55+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Greek (Greece) (http://www.transifex.com/oca/OCA-connector-8-0/language/el_GR/)\n"
 "MIME-Version: 1.0\n"
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Ονομασία"
 
 #. module: connector
 #: help:connector.checkpoint,name:0

--- a/connector/i18n/en_AU.po
+++ b/connector/i18n/en_AU.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-21 19:23+0000\n"
+"PO-Revision-Date: 2016-12-27 08:23+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: French (Canada) (http://www.transifex.com/oca/OCA-connector-8-0/language/fr_CA/)\n"
+"Language-Team: English (Australia) (http://www.transifex.com/oca/OCA-connector-8-0/language/en_AU/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: fr_CA\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: en_AU\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Annuler"
+msgstr "Cancel"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Créé par"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Créé par"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Créé le"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Afficher le nom"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -342,7 +342,7 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr "Identifiant"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Dernière mise à jour par"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Dernière mise à jour par"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Dernière mise à jour le"
+msgstr ""
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -483,13 +483,13 @@ msgstr ""
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr "Modèle"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Nom"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,name:0

--- a/connector/i18n/en_GB.po
+++ b/connector/i18n/en_GB.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-22 16:25+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:40+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: English (United Kingdom) (http://www.transifex.com/oca/OCA-connector-8-0/language/en_GB/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Company"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/en_GB.po
+++ b/connector/i18n/en_GB.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:40+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:27+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: English (United Kingdom) (http://www.transifex.com/oca/OCA-connector-8-0/language/en_GB/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Active"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/en_GB.po
+++ b/connector/i18n/en_GB.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-11-22 16:25+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: English (United Kingdom) (http://www.transifex.com/oca/OCA-connector-8-0/language/en_GB/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
+"Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr "Cancel"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Channel"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Created by"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Created on"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Date of the last message posted on the record."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Description"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Display Name"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Followers"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Group By"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "If checked new messages require your attention."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Last Message Date"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Last Modified on"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Last Updated by"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Last Updated on"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Messages"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Messages and communication history"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Name"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Unread Messages"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "or"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/es.po
+++ b/connector/i18n/es.po
@@ -13,7 +13,7 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-04 09:43+0000\n"
+"PO-Revision-Date: 2016-11-25 14:56+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (http://www.transifex.com/oca/OCA-connector-8-0/language/es/)\n"
 "MIME-Version: 1.0\n"
@@ -156,7 +156,7 @@ msgstr "Hcer clic en"
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Compañía"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -246,7 +246,7 @@ msgstr "Fecha de finalización"
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "Fecha del último mensaje publicado en el registro."
 
 #. module: connector
 #: field:queue.job,name:0
@@ -423,7 +423,7 @@ msgstr "Última Comprobación Viva"
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "Fecha del último mensaje"
 
 #. module: connector
 #: field:connector.backend,__last_update:0

--- a/connector/i18n/es_AR.po
+++ b/connector/i18n/es_AR.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-10-11 09:48+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Spanish (Argentina) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_AR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
+"Language: es_AR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Canal"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Canales"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Creado por"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Creado en"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Fecha del último mensaje publicado en el registro."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Descripción"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Mostrar Nombre"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Seguidores"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Agrupar por"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Si esta marcado, los nuevos mensajes requieren su atención."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Fecha de último mensaje"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Última modificación en"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Última actualización realizada por"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Última actualización el"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Mensajes"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Historial de mensajes y comunicación"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Nombre"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Mensajes No Leídos"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "o"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/es_AR.po
+++ b/connector/i18n/es_AR.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-11 09:48+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:23+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Argentina) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_AR/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/es_CL.po
+++ b/connector/i18n/es_CL.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-10-11 09:48+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Spanish (Chile) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_CL/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
+"Language: es_CL\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr ""
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Creado por"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Creado en"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Fecha del último mensaje publicado en el registro."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Descripción"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Nombre mostrado"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Seguidores"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Agrupar por"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr "ID"
+msgstr "ID (identificación)"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Si está marcado, hay nuevos mensajes que requieren su atención"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Fecha del último mensaje"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Última modificación en"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Última actualización de"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Última actualización en"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Mensajes"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Nombre"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "o"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/es_CL.po
+++ b/connector/i18n/es_CL.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-11 09:48+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:24+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Chile) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_CL/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/es_CO.po
+++ b/connector/i18n/es_CO.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-10-11 09:51+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Spanish (Colombia) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_CO/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
+"Language: es_CO\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Canal"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Canales"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Creado por"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Creado"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Fecha del último mensaje publicado en el registro."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Descripción"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Nombre Público"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Seguidores"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Agrupar por"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Si está marcado, hay nuevos mensajes que requieren su atención"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Fecha del Último Mensaje"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Última Modificación el"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Actualizado por"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Actualizado"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Mensajes"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Historial de mensajes y de comunicación"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Nombre"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -577,7 +577,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
 msgid "Related"
-msgstr ""
+msgstr "Relacionados"
 
 #. module: connector
 #: code:addons/connector/related_action.py:48
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Mensajes sin Leer"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "o"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/es_CO.po
+++ b/connector/i18n/es_CO.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-11 09:51+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:22+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Colombia) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_CO/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/es_CR.po
+++ b/connector/i18n/es_CR.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:26+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:56+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Costa Rica) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_CR/)\n"
 "MIME-Version: 1.0\n"
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr ""
+msgstr "Canal"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Canales"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -220,7 +220,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "Creado en"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -246,7 +246,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "Descripción"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "Agrupar por"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,7 +342,7 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
@@ -472,7 +472,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr ""
+msgstr "Mensajes"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Nombre"
 
 #. module: connector
 #: help:connector.checkpoint,name:0

--- a/connector/i18n/es_CR.po
+++ b/connector/i18n/es_CR.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-27 08:24+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-03-02 22:14+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Costa Rica) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_CR/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Compañía"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Estado"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/es_CR.po
+++ b/connector/i18n/es_CR.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-03-02 22:14+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:28+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Costa Rica) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_CR/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Activo"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/es_CR.po
+++ b/connector/i18n/es_CR.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:56+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-23 08:33+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Costa Rica) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_CR/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Tarea"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/es_CR.po
+++ b/connector/i18n/es_CR.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-23 08:33+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:24+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Costa Rica) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_CR/)\n"
 "MIME-Version: 1.0\n"
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "Creado por"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "Ultima actualización por"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "Ultima actualización en"
 
 #. module: connector
 #: field:external.binding,sync_date:0

--- a/connector/i18n/es_DO.po
+++ b/connector/i18n/es_DO.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-11 09:49+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:25+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Dominican Republic) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_DO/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/es_DO.po
+++ b/connector/i18n/es_DO.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-10-11 09:49+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Spanish (Dominican Republic) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_DO/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
+"Language: es_DO\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Canal"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Canales"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Creado por"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Creado en"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Fecha del último mensaje publicado en el registro."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Descripción"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Nombre mostrado"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Seguidores"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Agrupar por"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Si está marcado, hay nuevos mensajes que requieren su atención"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Fecha del último mensaje"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Última modificación en"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Última actualización de"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Última actualización en"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Mensajes"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Mensajes e historial de comunicación"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Nombre"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Mensajes sin leer"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "o"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/es_EC.po
+++ b/connector/i18n/es_EC.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:56+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:40+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Ecuador) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_EC/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Compañia"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/es_EC.po
+++ b/connector/i18n/es_EC.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:40+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:23+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Ecuador) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_EC/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Activo"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/es_EC.po
+++ b/connector/i18n/es_EC.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:25+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:56+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Ecuador) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_EC/)\n"
 "MIME-Version: 1.0\n"
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr ""
+msgstr "Canal"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Canales"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "Creado por"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "Creado en"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "Fecha del último mensaje publicado en el registro."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "Descripción"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr ""
+msgstr "Nombre mostrado"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr ""
+msgstr "Seguidores"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "Agrupar por"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "ID (identificación)"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr ""
+msgstr "Si está marcado, hay nuevos mensajes que requieren su atención"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "Fecha del último mensaje"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr ""
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "Última modificación en"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "Última actualización de"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "Última actualización en"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr ""
+msgstr "Mensajes"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr ""
+msgstr "Mensajes e historial de comunicación"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Nombre"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -577,7 +577,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
 msgid "Related"
-msgstr ""
+msgstr "Relacionados"
 
 #. module: connector
 #: code:addons/connector/related_action.py:48
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr ""
+msgstr "Mensajes sin leer"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "o"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/es_MX.po
+++ b/connector/i18n/es_MX.po
@@ -3,13 +3,14 @@
 # * connector
 # 
 # Translators:
-# Jesus Alan Ramos Rodriguez <alan.ramos@jarsa.com.mx>, 2015
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2014
+# Jesús Alan Ramos Rodríguez <alan.ramos@jarsa.com.mx>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-16 06:23+0000\n"
-"PO-Revision-Date: 2015-10-15 13:38+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Mexico) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_MX/)\n"
 "MIME-Version: 1.0\n"
@@ -91,7 +92,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #. module: connector
-#: code:addons/connector/queue/job.py:574
+#: code:addons/connector/queue/job.py:619
 #, python-format
 msgid "Canceled. Nothing to do."
 msgstr ""
@@ -213,7 +214,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "Creado por"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -221,7 +222,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "Creado en"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -242,12 +243,24 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "Fecha de último trabajo realizado en esta cuenta"
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "Descripción"
+
+#. module: connector
+#: field:connector.backend,display_name:0
+#: field:connector.checkpoint,display_name:0
+#: field:connector.checkpoint.review,display_name:0
+#: field:connector.config.settings,display_name:0
+#: field:external.binding,display_name:0 field:queue.job,display_name:0
+#: field:queue.job.channel,display_name:0
+#: field:queue.job.function,display_name:0
+#: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
+msgid "Display Name"
+msgstr "Nombre desplegado"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -331,12 +344,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr ""
+msgstr "Si se marca, los nuevos mensajes requieren su atención"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -407,7 +420,19 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "Fecha de último mensaje"
+
+#. module: connector
+#: field:connector.backend,__last_update:0
+#: field:connector.checkpoint,__last_update:0
+#: field:connector.checkpoint.review,__last_update:0
+#: field:connector.config.settings,__last_update:0
+#: field:external.binding,__last_update:0 field:queue.job,__last_update:0
+#: field:queue.job.channel,__last_update:0
+#: field:queue.job.function,__last_update:0
+#: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
+msgid "Last Modified on"
+msgstr "Ultima modificacion realizada"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -415,7 +440,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "Ultima actualizacion por"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -423,7 +448,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "Ultima actualización realizada"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -454,7 +479,7 @@ msgstr "Mensajes"
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr ""
+msgstr "Mensajes e historial de comunicación"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -467,6 +492,11 @@ msgstr "Modelo"
 #: field:queue.job.function,name:0
 msgid "Name"
 msgstr "Nombre"
+
+#. module: connector
+#: help:connector.checkpoint,name:0
+msgid "Name of the record to review"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -532,8 +562,18 @@ msgid "Queue Worker"
 msgstr ""
 
 #. module: connector
+#: field:connector.checkpoint,record:0
+msgid "Record"
+msgstr ""
+
+#. module: connector
 #: field:connector.checkpoint,record_id:0
 msgid "Record ID"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,name:0
+msgid "Record Name"
 msgstr ""
 
 #. module: connector
@@ -661,6 +701,11 @@ msgid "The record has been imported from this backend"
 msgstr ""
 
 #. module: connector
+#: help:connector.checkpoint,record:0
+msgid "The record to review."
+msgstr ""
+
+#. module: connector
 #: view:connector.checkpoint.review:connector.view_connector_checkpoint_review
 msgid "The selected checkpoints will be set as reviewed."
 msgstr ""
@@ -689,7 +734,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr ""
+msgstr "Mensajes sin leer"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -737,7 +782,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "ó"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/es_MX.po
+++ b/connector/i18n/es_MX.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-23 08:32+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:40+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Mexico) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_MX/)\n"
 "MIME-Version: 1.0\n"
@@ -99,13 +99,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -527,7 +527,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -651,7 +651,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -676,7 +676,7 @@ msgstr "Estado"
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Estado"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/es_MX.po
+++ b/connector/i18n/es_MX.po
@@ -5,12 +5,13 @@
 # Translators:
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2014
 # Jesús Alan Ramos Rodríguez <alan.ramos@jarsa.com.mx>, 2015
+# Jesús Alan Ramos Rodríguez <alan.ramos@jarsa.com.mx>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-23 08:32+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Mexico) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_MX/)\n"
 "MIME-Version: 1.0\n"
@@ -686,7 +687,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Tarea"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/es_PE.po
+++ b/connector/i18n/es_PE.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-10-11 09:50+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Spanish (Peru) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_PE/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
+"Language: es_PE\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Canal"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Creado por"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Creado en"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Fecha del ultimo mensaje actualizado en el registro."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Descripción"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Nombre a Mostrar"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Seguidores"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Agrupado por"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Si está marcado nuevos mensajes requieren su atención."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Fecha del último mensaje"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Ultima Modificación en"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Actualizado última vez por"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Ultima Actualización"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Mensajes"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Historial de mensajes y comunicación"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Nombre"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Mensajes no leidos"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "o"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/es_PY.po
+++ b/connector/i18n/es_PY.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-11 09:47+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:21+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Paraguay) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_PY/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/es_PY.po
+++ b/connector/i18n/es_PY.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-10-11 09:47+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Spanish (Paraguay) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_PY/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
+"Language: es_PY\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Canal"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Creado por"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Creado en"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr ""
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Descripción"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Seguidores"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Agrupado por"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Si marcado la nueva mensaje requiere atencion"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Fecha de la ultima mensaje"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Ultima actualización por"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Ultima actualización en"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Mensajes"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Mensajes y historial de comunicación"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Nombre"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Mensajes sin leer"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/es_VE.po
+++ b/connector/i18n/es_VE.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:26+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:55+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Venezuela) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_VE/)\n"
 "MIME-Version: 1.0\n"
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr ""
+msgstr "Canal"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "Creado por"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "Creado en"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -246,7 +246,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "Descripción"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr ""
+msgstr "Mostrar nombre"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "Agrupar por"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,7 +342,7 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
@@ -430,7 +430,7 @@ msgstr ""
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "Modificada por última vez"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "Última actualización realizada por"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "Ultima actualizacion en"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,7 +472,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr ""
+msgstr "Mensajes"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Nombre"
 
 #. module: connector
 #: help:connector.checkpoint,name:0

--- a/connector/i18n/es_VE.po
+++ b/connector/i18n/es_VE.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-23 08:40+0000\n"
+"POT-Creation-Date: 2017-07-01 01:36+0000\n"
+"PO-Revision-Date: 2017-08-03 13:34+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Venezuela) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_VE/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -668,7 +668,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr ""
+msgstr "Provincia"
 
 #. module: connector
 #: field:connector.checkpoint,state:0

--- a/connector/i18n/es_VE.po
+++ b/connector/i18n/es_VE.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:55+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-23 08:40+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Venezuela) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_VE/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Tarea"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/es_VE.po
+++ b/connector/i18n/es_VE.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-01 01:36+0000\n"
-"PO-Revision-Date: 2017-08-03 13:34+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:27+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Spanish (Venezuela) (http://www.transifex.com/oca/OCA-connector-8-0/language/es_VE/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Activo"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/et.po
+++ b/connector/i18n/et.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:25+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Estonian (http://www.transifex.com/oca/OCA-connector-8-0/language/et/)\n"
 "MIME-Version: 1.0\n"
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr ""
+msgstr "Allikas"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "Loonud"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "Loodud"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -246,7 +246,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "Kirjeldus"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr ""
+msgstr "Näidatav nimi"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr ""
+msgstr "Jälgijad"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "Rühmitamine"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr ""
+msgstr "Kui kontrollitud, siis uued sõnumid nõuavad Su tähelepanu."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "Viimase sõnumi kuupäev"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr ""
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "Viimati muudetud"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "Viimati uuendatud"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "Viimati uuendatud"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr ""
+msgstr "Sõnumid"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr ""
+msgstr "Sõnumite ja kommunikatsiooni ajalugu"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Nimi"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr ""
+msgstr "Lugemata sõnumid"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "või"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/et.po
+++ b/connector/i18n/et.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 11:10+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:26+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Estonian (http://www.transifex.com/oca/OCA-connector-8-0/language/et/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Aktiivne"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/et.po
+++ b/connector/i18n/et.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 11:10+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Estonian (http://www.transifex.com/oca/OCA-connector-8-0/language/et/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Ettevõte"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Olek"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/eu.po
+++ b/connector/i18n/eu.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-27 08:26+0000\n"
+"POT-Creation-Date: 2017-02-04 01:13+0000\n"
+"PO-Revision-Date: 2017-02-23 15:58+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Basque (http://www.transifex.com/oca/OCA-connector-8-0/language/eu/)\n"
 "MIME-Version: 1.0\n"
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Enpresa"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -483,7 +483,7 @@ msgstr "Messages and communication history"
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr ""
+msgstr "Model"
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0

--- a/connector/i18n/eu.po
+++ b/connector/i18n/eu.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-11 09:51+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:26+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Basque (http://www.transifex.com/oca/OCA-connector-8-0/language/eu/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Ezeztatu"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/eu.po
+++ b/connector/i18n/eu.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-10-11 09:51+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Basque (http://www.transifex.com/oca/OCA-connector-8-0/language/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
+"Language: eu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Kanala"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Nork sortua"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Created on"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Date of the last message posted on the record."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Deskribapena"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Izena erakutsi"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Followers"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Group By"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "If checked new messages require your attention."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Last Message Date"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Last Updated by"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Last Updated on"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Mezuak"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Messages and communication history"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Izena"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Irakurri gabeko mezuak"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "or"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/fa.po
+++ b/connector/i18n/fa.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-11 09:49+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:25+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Persian (http://www.transifex.com/oca/OCA-connector-8-0/language/fa/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "لغو"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/fa.po
+++ b/connector/i18n/fa.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-10-11 09:49+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Persian (http://www.transifex.com/oca/OCA-connector-8-0/language/fa/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: fa\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "کانال"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "کانال‌ها"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "ایجاد شده توسط"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "ایجاد شده در"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "تاریخ آخرین پیغام پست شده از این رکورد"
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "توصیف"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "نام نمایشی"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "دنبال‌کنندگان"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "گروه‌بندی برمبنای"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr "ID"
+msgstr "شناسه"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "اگر این گزینه را انتخاب کنید، پیام‌های جدید به توجه شما نیاز خواهند داشت"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "تاریخ آخرین پیام"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "تاریخ آخرین به‌روزرسانی"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "آخرین به روز رسانی توسط"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "آخرین به روز رسانی در"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "پیام‌ها"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "پیام‌ها و تاریخچه ارتباط"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "نام"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "پیام های ناخوانده"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "یا"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/fi.po
+++ b/connector/i18n/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-04 09:43+0000\n"
+"PO-Revision-Date: 2016-11-25 14:55+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Finnish (http://www.transifex.com/oca/OCA-connector-8-0/language/fi/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Peruuta"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -241,7 +241,7 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "Viimeisimmän lähetetyn viestin päiväys."
 
 #. module: connector
 #: field:queue.job,name:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr ""
+msgstr "Seuraajat"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -325,7 +325,7 @@ msgstr ""
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 msgid "Group By..."
-msgstr ""
+msgstr "Ryhmittele..."
 
 #. module: connector
 #: help:connector.checkpoint,message_summary:0
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr ""
+msgstr "Jos valittuna, uudet viestit vaatii toimenpiteitä."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "Viimeisimmän viestin päiväys"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -472,7 +472,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr ""
+msgstr "Viestejä"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
@@ -483,13 +483,13 @@ msgstr ""
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr ""
+msgstr "Mall"
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Nimi"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -673,7 +673,7 @@ msgstr "Tila"
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Tila"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr ""
+msgstr "Lukemattomia viestejä"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0

--- a/connector/i18n/fi.po
+++ b/connector/i18n/fi.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-23 08:32+0000\n"
+"POT-Creation-Date: 2017-01-07 01:20+0000\n"
+"PO-Revision-Date: 2017-01-13 09:29+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Finnish (http://www.transifex.com/oca/OCA-connector-8-0/language/fi/)\n"
 "MIME-Version: 1.0\n"
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "tai"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/fi.po
+++ b/connector/i18n/fi.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-04 01:13+0000\n"
-"PO-Revision-Date: 2017-02-23 12:30+0000\n"
+"POT-Creation-Date: 2017-05-01 16:08+0000\n"
+"PO-Revision-Date: 2017-05-11 14:14+0000\n"
 "Last-Translator: Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>\n"
 "Language-Team: Finnish (http://www.transifex.com/oca/OCA-connector-8-0/language/fi/)\n"
 "MIME-Version: 1.0\n"
@@ -97,13 +97,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -299,7 +299,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Failed"
-msgstr ""
+msgstr "Epäonnistunut"
 
 #. module: connector
 #: field:connector.checkpoint,message_follower_ids:0
@@ -321,7 +321,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "Ryhmittele"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -525,7 +525,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -649,7 +649,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/fi.po
+++ b/connector/i18n/fi.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:55+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-23 08:32+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Finnish (http://www.transifex.com/oca/OCA-connector-8-0/language/fi/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Tehtävä"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/fi.po
+++ b/connector/i18n/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-01-07 01:20+0000\n"
-"PO-Revision-Date: 2017-01-13 09:29+0000\n"
+"PO-Revision-Date: 2017-01-17 12:11+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Finnish (http://www.transifex.com/oca/OCA-connector-8-0/language/fi/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Aktiivinen"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Yritys"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -542,7 +542,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,priority:0
 msgid "Priority"
-msgstr ""
+msgstr "Prioriteetti"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_queue

--- a/connector/i18n/fi.po
+++ b/connector/i18n/fi.po
@@ -3,13 +3,14 @@
 # * connector
 # 
 # Translators:
+# Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2017
 msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-07 01:20+0000\n"
-"PO-Revision-Date: 2017-01-17 12:11+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
+"POT-Creation-Date: 2017-02-04 01:13+0000\n"
+"PO-Revision-Date: 2017-02-23 12:30+0000\n"
+"Last-Translator: Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>\n"
 "Language-Team: Finnish (http://www.transifex.com/oca/OCA-connector-8-0/language/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -347,7 +348,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Jos valittuna, uudet viestit vaatii toimenpiteitä."
+msgstr "Jos valittuna, uudet viestit vaativat toimenpiteitä."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form

--- a/connector/i18n/fr.po
+++ b/connector/i18n/fr.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-16 21:46+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 23:05+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: French (http://www.transifex.com/oca/OCA-connector-8-0/language/fr/)\n"
 "MIME-Version: 1.0\n"
@@ -98,13 +98,13 @@ msgid "Canceled. Nothing to do."
 msgstr "Annulé. Rien à faire."
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr "Impossible de changer le canal racine"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr "Impossible de supprimer le canal racine"
@@ -526,7 +526,7 @@ msgid "Parent Channel"
 msgstr "Canal parent"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr "Canal parent requis"
@@ -650,7 +650,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr "Partager ou embarquer n'importe quel écran d'Odoo."
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/fr_CA.po
+++ b/connector/i18n/fr_CA.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-11-22 12:24+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: French (Canada) (http://www.transifex.com/oca/OCA-connector-8-0/language/fr_CA/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: fr_CA\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr ""
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr ""
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr ""
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,24 +472,24 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr ""
+msgstr "Modèle"
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Nom"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/fr_CH.po
+++ b/connector/i18n/fr_CH.po
@@ -10,12 +10,12 @@ msgstr ""
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
 "PO-Revision-Date: 2016-11-25 14:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: French (Switzerland) (http://www.transifex.com/oca/OCA-connector-8-0/language/fr_CH/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: fr_CH\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr "Annuler"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr ""
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Créé par"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Créé le"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr ""
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Modifié par"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Modifié le"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -668,7 +668,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr ""
+msgstr "État"
 
 #. module: connector
 #: field:connector.checkpoint,state:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/fr_CH.po
+++ b/connector/i18n/fr_CH.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"POT-Creation-Date: 2016-11-26 04:06+0000\n"
+"PO-Revision-Date: 2016-12-01 10:40+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: French (Switzerland) (http://www.transifex.com/oca/OCA-connector-8-0/language/fr_CH/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Actif"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr ""
+msgstr "Nom affiché"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -430,7 +430,7 @@ msgstr ""
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "Dernière modification le"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0

--- a/connector/i18n/fr_FR.po
+++ b/connector/i18n/fr_FR.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-21 19:23+0000\n"
+"PO-Revision-Date: 2016-12-27 08:20+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: French (Canada) (http://www.transifex.com/oca/OCA-connector-8-0/language/fr_CA/)\n"
+"Language-Team: French (France) (http://www.transifex.com/oca/OCA-connector-8-0/language/fr_FR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: fr_CA\n"
+"Language: fr_FR\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: connector
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Créé par"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Créé par"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Créé le"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Afficher le nom"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -342,7 +342,7 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr "Identifiant"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Dernière mise à jour par"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Dernière mise à jour par"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Dernière mise à jour le"
+msgstr ""
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -483,13 +483,13 @@ msgstr ""
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr "Modèle"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Nom"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,name:0

--- a/connector/i18n/gl.po
+++ b/connector/i18n/gl.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:58+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-23 08:33+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Galician (http://www.transifex.com/oca/OCA-connector-8-0/language/gl/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Tarefa"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/gl.po
+++ b/connector/i18n/gl.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-23 08:33+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:39+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Galician (http://www.transifex.com/oca/OCA-connector-8-0/language/gl/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Compañía"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Estado"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/gl.po
+++ b/connector/i18n/gl.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:25+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:58+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Galician (http://www.transifex.com/oca/OCA-connector-8-0/language/gl/)\n"
 "MIME-Version: 1.0\n"
@@ -430,7 +430,7 @@ msgstr ""
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "Última modificación"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "ou"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/gl.po
+++ b/connector/i18n/gl.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:39+0000\n"
+"POT-Creation-Date: 2017-07-01 01:36+0000\n"
+"PO-Revision-Date: 2017-08-11 11:55+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Galician (http://www.transifex.com/oca/OCA-connector-8-0/language/gl/)\n"
 "MIME-Version: 1.0\n"
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Nome"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -668,7 +668,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr ""
+msgstr "Estado"
 
 #. module: connector
 #: field:connector.checkpoint,state:0

--- a/connector/i18n/gl_ES.po
+++ b/connector/i18n/gl_ES.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-11-22 16:25+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Galician (Spain) (http://www.transifex.com/oca/OCA-connector-8-0/language/gl_ES/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
+"Language: gl_ES\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr ""
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr ""
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr ""
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/he.po
+++ b/connector/i18n/he.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-10-11 09:51+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Hebrew (http://www.transifex.com/oca/OCA-connector-8-0/language/he/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
+"Language: he\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "ערוץ"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "ערוצים"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "נוצר על ידי"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "נוצר ב-"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "תאריך הודעה אחרונה שפורסמה ברשומה."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "תיאור"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "השם המוצג"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "עוקבים"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "קבץ לפי"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr "ID"
+msgstr "מזהה"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "אם מסומן אז הודעה חדשה דורשת התייחסותכם."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "תאריך הודעה אחרונה"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "תאריך שינוי אחרון"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "עודכן לאחרונה על ידי"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "עודכן לאחרונה על"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "הודעות"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "היסטוריית הודעות ותקשורת"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "שם"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "הודעות שלא נקראו"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "או"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/he.po
+++ b/connector/i18n/he.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-11 09:51+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:25+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Hebrew (http://www.transifex.com/oca/OCA-connector-8-0/language/he/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "בטל"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/hi.po
+++ b/connector/i18n/hi.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-21 19:23+0000\n"
+"PO-Revision-Date: 2016-12-27 08:24+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: French (Canada) (http://www.transifex.com/oca/OCA-connector-8-0/language/fr_CA/)\n"
+"Language-Team: Hindi (http://www.transifex.com/oca/OCA-connector-8-0/language/hi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: fr_CA\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: hi\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Annuler"
+msgstr "रद्द"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Créé par"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Créé par"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Créé le"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Afficher le nom"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -342,7 +342,7 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr "Identifiant"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Dernière mise à jour par"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Dernière mise à jour par"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Dernière mise à jour le"
+msgstr ""
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -483,13 +483,13 @@ msgstr ""
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr "Modèle"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Nom"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,name:0

--- a/connector/i18n/hr.po
+++ b/connector/i18n/hr.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-05 06:35+0000\n"
+"PO-Revision-Date: 2016-11-25 14:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Croatian (http://www.transifex.com/oca/OCA-connector-8-0/language/hr/)\n"
 "MIME-Version: 1.0\n"
@@ -113,7 +113,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr ""
+msgstr "Kanal"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -127,7 +127,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Kanali prodaje"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -242,12 +242,12 @@ msgstr "Datum izvršenja"
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "Datum zadnjeg zapisa"
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "Opis"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -264,7 +264,7 @@ msgstr "Naziv "
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr ""
+msgstr "Izvršeno"
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -305,7 +305,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr ""
+msgstr "Pratitelji"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -321,7 +321,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "Grupiraj po"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -419,7 +419,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "Datum zadnje poruke"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -478,7 +478,7 @@ msgstr "Poruke"
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr ""
+msgstr "Poruke i povijest"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -490,7 +490,7 @@ msgstr "Model"
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Naziv"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -533,7 +533,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Pending"
-msgstr ""
+msgstr "U tijeku"
 
 #. module: connector
 #: field:queue.job,func:0
@@ -578,7 +578,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
 msgid "Related"
-msgstr ""
+msgstr "Povezano"
 
 #. module: connector
 #: code:addons/connector/related_action.py:48
@@ -669,7 +669,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr ""
+msgstr "Status"
 
 #. module: connector
 #: field:connector.checkpoint,state:0

--- a/connector/i18n/hr.po
+++ b/connector/i18n/hr.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-26 04:06+0000\n"
-"PO-Revision-Date: 2016-11-29 09:33+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:40+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Croatian (http://www.transifex.com/oca/OCA-connector-8-0/language/hr/)\n"
 "MIME-Version: 1.0\n"
@@ -97,13 +97,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -525,7 +525,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -649,7 +649,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -674,7 +674,7 @@ msgstr "Status"
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/hr.po
+++ b/connector/i18n/hr.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"POT-Creation-Date: 2016-11-26 04:06+0000\n"
+"PO-Revision-Date: 2016-11-29 09:33+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Croatian (http://www.transifex.com/oca/OCA-connector-8-0/language/hr/)\n"
 "MIME-Version: 1.0\n"
@@ -46,7 +46,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Aktivno"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -152,7 +152,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Poduzeće"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0

--- a/connector/i18n/hr.po
+++ b/connector/i18n/hr.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:40+0000\n"
+"POT-Creation-Date: 2017-05-01 16:08+0000\n"
+"PO-Revision-Date: 2017-05-11 14:12+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Croatian (http://www.transifex.com/oca/OCA-connector-8-0/language/hr/)\n"
 "MIME-Version: 1.0\n"
@@ -680,7 +680,7 @@ msgstr "Status"
 #: field:connector.checkpoint,message_summary:0
 #: field:queue.job,message_summary:0
 msgid "Summary"
-msgstr ""
+msgstr "Sažetak"
 
 #. module: connector
 #: field:queue.job,func_string:0

--- a/connector/i18n/hr.po
+++ b/connector/i18n/hr.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-05-01 16:08+0000\n"
-"PO-Revision-Date: 2017-05-11 14:12+0000\n"
+"PO-Revision-Date: 2017-05-13 18:19+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Croatian (http://www.transifex.com/oca/OCA-connector-8-0/language/hr/)\n"
 "MIME-Version: 1.0\n"
@@ -543,7 +543,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,priority:0
 msgid "Priority"
-msgstr ""
+msgstr "Prioritet"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_queue

--- a/connector/i18n/hr_HR.po
+++ b/connector/i18n/hr_HR.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:41+0000\n"
+"POT-Creation-Date: 2017-07-01 01:36+0000\n"
+"PO-Revision-Date: 2017-08-11 11:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Croatian (Croatia) (http://www.transifex.com/oca/OCA-connector-8-0/language/hr_HR/)\n"
 "MIME-Version: 1.0\n"
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Naziv"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -668,7 +668,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr ""
+msgstr "Oblast/Županija"
 
 #. module: connector
 #: field:connector.checkpoint,state:0

--- a/connector/i18n/hr_HR.po
+++ b/connector/i18n/hr_HR.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-25 01:26+0000\n"
-"PO-Revision-Date: 2017-03-02 22:14+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:41+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Croatian (Croatia) (http://www.transifex.com/oca/OCA-connector-8-0/language/hr_HR/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Poduzeće"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/hr_HR.po
+++ b/connector/i18n/hr_HR.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-05 06:29+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:23+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Croatian (Croatia) (http://www.transifex.com/oca/OCA-connector-8-0/language/hr_HR/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Otkaži"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/hr_HR.po
+++ b/connector/i18n/hr_HR.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-27 08:23+0000\n"
+"POT-Creation-Date: 2017-02-25 01:26+0000\n"
+"PO-Revision-Date: 2017-03-02 22:14+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Croatian (Croatia) (http://www.transifex.com/oca/OCA-connector-8-0/language/hr_HR/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Zadatak"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/hu.po
+++ b/connector/i18n/hu.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-08-21 14:26+0000\n"
-"PO-Revision-Date: 2015-06-17 07:37+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-22 16:44+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Hungarian (http://www.transifex.com/oca/OCA-connector-8-0/language/hu/)\n"
 "MIME-Version: 1.0\n"
@@ -91,19 +91,19 @@ msgid "Cancel"
 msgstr "Mégsem"
 
 #. module: connector
-#: code:addons/connector/queue/job.py:571
+#: code:addons/connector/queue/job.py:619
 #, python-format
 msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:456
+#: code:addons/connector/queue/model.py:457
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:463
+#: code:addons/connector/queue/model.py:464
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -113,7 +113,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr ""
+msgstr "Csatorna"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -127,7 +127,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Csatornák"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -213,7 +213,7 @@ msgstr "Létrehozás dátuma"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "Készítette"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -221,7 +221,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "Létrehozás dátuma"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -242,12 +242,24 @@ msgstr "Befejezés dátuma"
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "A feljegyzésen történt utolsó levelezés dátuma."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
 msgstr "Leírás"
+
+#. module: connector
+#: field:connector.backend,display_name:0
+#: field:connector.checkpoint,display_name:0
+#: field:connector.checkpoint.review,display_name:0
+#: field:connector.config.settings,display_name:0
+#: field:external.binding,display_name:0 field:queue.job,display_name:0
+#: field:queue.job.channel,display_name:0
+#: field:queue.job.function,display_name:0
+#: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
+msgid "Display Name"
+msgstr "Név megjelenítése"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -309,7 +321,7 @@ msgstr "Adjon hozzáférést a vevőknek a dokumentumaikhoz."
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "Csoportosítás..."
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -331,7 +343,7 @@ msgstr "A chettelés összegzést megállítja (üzenetek száma,...). Ez az ös
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
@@ -368,6 +380,7 @@ msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search
+#: field:queue.job,job_function_id:0
 msgid "Job Function"
 msgstr ""
 
@@ -388,11 +401,6 @@ msgid "Job failed"
 msgstr "Feladat meghiusult"
 
 #. module: connector
-#: field:queue.job,job_function_id:0
-msgid "Job function id"
-msgstr ""
-
-#. module: connector
 #: model:ir.actions.act_window,name:connector.action_queue_job
 #: model:ir.ui.menu,name:connector.menu_queue_job
 #: view:queue.job:connector.view_queue_job_form
@@ -411,7 +419,19 @@ msgstr "Utolsó futó ellenőrzés"
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "Utolsó üzenet dátuma"
+
+#. module: connector
+#: field:connector.backend,__last_update:0
+#: field:connector.checkpoint,__last_update:0
+#: field:connector.checkpoint.review,__last_update:0
+#: field:connector.config.settings,__last_update:0
+#: field:external.binding,__last_update:0 field:queue.job,__last_update:0
+#: field:queue.job.channel,__last_update:0
+#: field:queue.job.function,__last_update:0
+#: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
+msgid "Last Modified on"
+msgstr "Utolsó frissítés dátuma"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -419,7 +439,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "Utoljára frissítve, által"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -427,7 +447,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "Utoljára frissítve "
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -440,7 +460,7 @@ msgid "Manage multiple companies"
 msgstr "Többes válallkozás kezelése"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:140
+#: code:addons/connector/queue/model.py:141
 #, python-format
 msgid "Manually set to done by %s"
 msgstr ""
@@ -467,15 +487,15 @@ msgid "Model"
 msgstr "Modell, minta"
 
 #. module: connector
-#: model:ir.model,name:connector.model_ir_module_module
-msgid "Module"
-msgstr ""
-
-#. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
 msgstr "Név"
+
+#. module: connector
+#: help:connector.checkpoint,name:0
+msgid "Name of the record to review"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -484,7 +504,7 @@ msgid "Need Review"
 msgstr "Felülvizsgálat szükséges"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:116
+#: code:addons/connector/queue/model.py:117
 #, python-format
 msgid "No action available for this job"
 msgstr ""
@@ -505,7 +525,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:448
+#: code:addons/connector/queue/model.py:449
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -541,14 +561,24 @@ msgid "Queue Worker"
 msgstr ""
 
 #. module: connector
+#: field:connector.checkpoint,record:0
+msgid "Record"
+msgstr ""
+
+#. module: connector
 #: field:connector.checkpoint,record_id:0
 msgid "Record ID"
 msgstr "Rekordazonosító ID"
 
 #. module: connector
+#: field:connector.checkpoint,name:0
+msgid "Record Name"
+msgstr ""
+
+#. module: connector
 #: view:queue.job:connector.view_queue_job_form
 msgid "Related"
-msgstr ""
+msgstr "Kapcsolódó"
 
 #. module: connector
 #: code:addons/connector/related_action.py:48
@@ -619,7 +649,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:186
+#: code:addons/connector/queue/model.py:187
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -668,6 +698,11 @@ msgstr "A feladat nem lesz végrehajtva, ha a próbálkozások száma eléri a m
 #: help:connector.checkpoint,backend_id:0
 msgid "The record has been imported from this backend"
 msgstr "Erről a végpontról importált rekord"
+
+#. module: connector
+#: help:connector.checkpoint,record:0
+msgid "The record to review."
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint.review:connector.view_connector_checkpoint_review

--- a/connector/i18n/hu.po
+++ b/connector/i18n/hu.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-22 16:44+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:42+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Hungarian (http://www.transifex.com/oca/OCA-connector-8-0/language/hu/)\n"
 "MIME-Version: 1.0\n"
@@ -97,13 +97,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -152,7 +152,7 @@ msgstr "Kattintson erre"
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Vállalat"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -525,7 +525,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -649,7 +649,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/id.po
+++ b/connector/i18n/id.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-04 01:28+0000\n"
-"PO-Revision-Date: 2017-03-10 13:16+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 08:01+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Indonesian (http://www.transifex.com/oca/OCA-connector-8-0/language/id/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Aktif"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/id.po
+++ b/connector/i18n/id.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-10-11 09:47+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Indonesian (http://www.transifex.com/oca/OCA-connector-8-0/language/id/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: id\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Saluran"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Saluran"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Dibuat oleh"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Dibuat pada"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Tanggal pesan terakhir diposting pada catatan."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Keterangan"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Nama Tampilan"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Pengikut"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Dikelompokan berdasarkan .."
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Jika dicentang pesan baru membutuhkan perhatian Anda."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Tanggal pesan terakhir"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Terakhir Dimodifikasi pada"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Diperbaharui oleh"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Diperbaharui pada"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Pesan"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Pesan dan riwayat komunikasi"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Nama"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -577,7 +577,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
 msgid "Related"
-msgstr ""
+msgstr "Terkait"
 
 #. module: connector
 #: code:addons/connector/related_action.py:48
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Pesan Belum Dibaca"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "atau"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/id.po
+++ b/connector/i18n/id.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-27 08:22+0000\n"
+"POT-Creation-Date: 2017-03-04 01:28+0000\n"
+"PO-Revision-Date: 2017-03-10 13:16+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Indonesian (http://www.transifex.com/oca/OCA-connector-8-0/language/id/)\n"
 "MIME-Version: 1.0\n"
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Perusahaan"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0

--- a/connector/i18n/id.po
+++ b/connector/i18n/id.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-11 09:47+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:22+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Indonesian (http://www.transifex.com/oca/OCA-connector-8-0/language/id/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Batalkan"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/it.po
+++ b/connector/i18n/it.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-23 08:32+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Italian (http://www.transifex.com/oca/OCA-connector-8-0/language/it/)\n"
 "MIME-Version: 1.0\n"
@@ -371,7 +371,7 @@ msgstr "Importato da"
 #: field:connector.checkpoint,message_is_follower:0
 #: field:queue.job,message_is_follower:0
 msgid "Is a Follower"
-msgstr ""
+msgstr "È un follower"
 
 #. module: connector
 #: model:ir.model,name:connector.model_queue_job_channel

--- a/connector/i18n/it.po
+++ b/connector/i18n/it.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-04 09:43+0000\n"
+"PO-Revision-Date: 2016-11-25 14:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Italian (http://www.transifex.com/oca/OCA-connector-8-0/language/it/)\n"
 "MIME-Version: 1.0\n"
@@ -46,7 +46,7 @@ msgstr "Attiva il portale clienti"
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Attivo"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -242,7 +242,7 @@ msgstr "Data completamento"
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "Date of the last message posted on the record."
 
 #. module: connector
 #: field:queue.job,name:0
@@ -264,7 +264,7 @@ msgstr "Nome da visualizzare"
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr ""
+msgstr "Completato"
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -321,7 +321,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "Raggruppa per"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -419,7 +419,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "Last Message Date"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -484,13 +484,13 @@ msgstr ""
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr ""
+msgstr "Modello"
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Nome"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -674,13 +674,13 @@ msgstr "Stato"
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Stato"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0
 #: field:queue.job,message_summary:0
 msgid "Summary"
-msgstr ""
+msgstr "Periodo Iva"
 
 #. module: connector
 #: field:queue.job,func_string:0

--- a/connector/i18n/ja.po
+++ b/connector/i18n/ja.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-21 19:25+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:45+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Japanese (http://www.transifex.com/oca/OCA-connector-8-0/language/ja/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "会社"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/ja.po
+++ b/connector/i18n/ja.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:45+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:26+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Japanese (http://www.transifex.com/oca/OCA-connector-8-0/language/ja/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "有効"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/ja.po
+++ b/connector/i18n/ja.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-22 16:24+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-21 19:25+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Japanese (http://www.transifex.com/oca/OCA-connector-8-0/language/ja/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "タスク"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/ja.po
+++ b/connector/i18n/ja.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-11-22 16:24+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Japanese (http://www.transifex.com/oca/OCA-connector-8-0/language/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: ja\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr "キャンセル"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "チャネル"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "チャネル"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "作成者"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "作成日"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "記録上の最後のメッセージが投稿された日"
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "説明"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "表示名"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "フォロワー"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "グループ化"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "最終メッセージ日"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "最終更新日"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "最終更新者"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "最終更新日"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "メッセージ"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "メッセージと通信履歴"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "名称"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "未読メッセージ"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "または"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/ko.po
+++ b/connector/i18n/ko.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-10-11 09:50+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Korean (http://www.transifex.com/oca/OCA-connector-8-0/language/ko/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: ko\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "채널"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "채널"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "작성자"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "작성일"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "레코드에 게시된 최근 메시지의 날짜."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "설명"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "표시 이름"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "팔로워"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "그룹화"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "선택하면 새로운 메시지를 주목할 필요가 있습니다."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "최근 메시지 날짜"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "최근 수정"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "최근 갱신한 사람"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "최근 갱신 날짜"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "메시지"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "메시지 및 대화 기록"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "이름"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -577,7 +577,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
 msgid "Related"
-msgstr ""
+msgstr "관련됨"
 
 #. module: connector
 #: code:addons/connector/related_action.py:48
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "읽지 않은 메시지"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "또는"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/ko.po
+++ b/connector/i18n/ko.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-11 09:50+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:26+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Korean (http://www.transifex.com/oca/OCA-connector-8-0/language/ko/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "취소"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/lo.po
+++ b/connector/i18n/lo.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-21 19:23+0000\n"
+"PO-Revision-Date: 2016-12-27 08:22+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: French (Canada) (http://www.transifex.com/oca/OCA-connector-8-0/language/fr_CA/)\n"
+"Language-Team: Lao (http://www.transifex.com/oca/OCA-connector-8-0/language/lo/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: fr_CA\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: lo\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Annuler"
+msgstr "ຍົກເລີອກ"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Créé par"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Créé par"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Créé le"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Afficher le nom"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -342,7 +342,7 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr "Identifiant"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Dernière mise à jour par"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Dernière mise à jour par"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Dernière mise à jour le"
+msgstr ""
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -483,13 +483,13 @@ msgstr ""
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr "Modèle"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Nom"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,name:0

--- a/connector/i18n/lt.po
+++ b/connector/i18n/lt.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-23 08:33+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:43+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Lithuanian (http://www.transifex.com/oca/OCA-connector-8-0/language/lt/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Įmonė"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Būsena"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/lt.po
+++ b/connector/i18n/lt.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:24+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:58+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Lithuanian (http://www.transifex.com/oca/OCA-connector-8-0/language/lt/)\n"
 "MIME-Version: 1.0\n"
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr ""
+msgstr "Kanalas"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Kanalai"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "Sukūrė"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "Sukurta"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "Paskutinė pranešimo publikavimo data šiame įraše."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "Aprašymas"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr ""
+msgstr "Vaizduojamas pavadinimas"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr ""
+msgstr "Prenumeratoriai"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "Grupuoti pagal"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr ""
+msgstr "Jeigu pažymėta, nauji pranešimai reikalaus jūsų dėmesio."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "Paskutinio pranešimo data"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr ""
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "Paskutinį kartą keista"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "Paskutinį kartą atnaujino"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "Paskutinį kartą atnaujinta"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr ""
+msgstr "Pranešimai"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr ""
+msgstr "Pranešimų ir komunikacijos istorija"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Pavadinimas"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr ""
+msgstr "Neskaityti pranešimai"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "arba"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/lt.po
+++ b/connector/i18n/lt.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:43+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:18+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Lithuanian (http://www.transifex.com/oca/OCA-connector-8-0/language/lt/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Aktyvus"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/lt.po
+++ b/connector/i18n/lt.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:58+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-23 08:33+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Lithuanian (http://www.transifex.com/oca/OCA-connector-8-0/language/lt/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Užduotis"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/lt_LT.po
+++ b/connector/i18n/lt_LT.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-01-07 01:20+0000\n"
-"PO-Revision-Date: 2017-01-13 09:26+0000\n"
+"PO-Revision-Date: 2017-01-11 15:35+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Portuguese (Portugal) (http://www.transifex.com/oca/OCA-connector-8-0/language/pt_PT/)\n"
+"Language-Team: Lithuanian (Lithuania) (http://www.transifex.com/oca/OCA-connector-8-0/language/lt_LT/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: pt_PT\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: lt_LT\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Ativo"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Cancelar"
+msgstr "Atšaukti"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Empresa"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Criado por"
+msgstr "Sukūrė"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Criado por"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Criado em"
+msgstr "Sukurta"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Data da última mensagem registada."
+msgstr ""
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Descrição"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Descrição"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Nome a Apresentar"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Concluído"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Seguidores"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -333,7 +333,7 @@ msgstr ""
 msgid ""
 "Holds the Chatter summary (number of messages, ...). This summary is "
 "directly in html format in order to be inserted in kanban views."
-msgstr "Contém o resumo do Chatter (número de mensagens, ...). Este resumo é formatado diretamente em html para poder ser inserido em vistas de kanban."
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,id:0 field:connector.checkpoint,id:0
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Se assinalada, há novas mensagens a requerer a sua atenção."
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -370,7 +370,7 @@ msgstr ""
 #: field:connector.checkpoint,message_is_follower:0
 #: field:queue.job,message_is_follower:0
 msgid "Is a Follower"
-msgstr "É um Seguidor"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_queue_job_channel
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Data da Última Mensagem"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Data da Última Mensagem"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Última Modificação Em"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Última Modificação Em"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Atualizado pela última vez por"
+msgstr "Paskutinį kartą atnaujino"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Atualizado pela última vez por"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Atualizado pela última vez em"
+msgstr "Paskutinį kartą atnaujinta"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,24 +472,24 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Mensagens"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "História das mensagens e comunicações"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr "Modelo"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Nome"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -532,7 +532,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Pending"
-msgstr "Pendente"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,func:0
@@ -673,18 +673,18 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr "Estado"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0
 #: field:queue.job,message_summary:0
 msgid "Summary"
-msgstr "Resumo"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr "Tarefa"
+msgstr ""
 
 #. module: connector
 #: help:queue.job,max_retries:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Mensagens não lidas"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "ou"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/lv.po
+++ b/connector/i18n/lv.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-11 09:48+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-22 14:06+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Latvian (http://www.transifex.com/oca/OCA-connector-8-0/language/lv/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Uzdevums"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/lv.po
+++ b/connector/i18n/lv.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-27 08:23+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:40+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Latvian (http://www.transifex.com/oca/OCA-connector-8-0/language/lv/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Uzņēmums"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Statuss"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/lv.po
+++ b/connector/i18n/lv.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-22 14:06+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:23+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Latvian (http://www.transifex.com/oca/OCA-connector-8-0/language/lv/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Atcelt"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/lv.po
+++ b/connector/i18n/lv.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-10-11 09:48+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Latvian (http://www.transifex.com/oca/OCA-connector-8-0/language/lv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: lv\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Kanāls"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Kanāli"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Izveidoja"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Izveidots"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Pēdējā ierakstam piesaistītā ziņojuma datums."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Apraksts"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Sekotāji"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Grupēt pēc"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Ja atzīmēts, tad jauni ziņojumi pieprasīs jūsu uzmanību."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Pēdēja ziņojuma datums"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Pēdējo reizi atjaunoja"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Pēdējās izmaiņas"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Ziņojumi"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Ziņojumu un komunikācijas vēsture"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Nosaukums"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Neizlasīti ziņojumi"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "vai"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/mk.po
+++ b/connector/i18n/mk.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-22 14:07+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:44+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Macedonian (http://www.transifex.com/oca/OCA-connector-8-0/language/mk/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Компанија"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Статус"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/mk.po
+++ b/connector/i18n/mk.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-22 16:25+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-22 14:07+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Macedonian (http://www.transifex.com/oca/OCA-connector-8-0/language/mk/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Задача"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/mk.po
+++ b/connector/i18n/mk.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-11-22 16:25+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Macedonian (http://www.transifex.com/oca/OCA-connector-8-0/language/mk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: mk\n"
+"Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : 1;\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Канали"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Креирано од"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Креирано на"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Датум на испраќање на последната порака"
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Опис"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Прикажи име"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Пратители"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Групирај по"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Доколку е штиклирано, новите пораки го бараат вашето внимание."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Датум на последна порака"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Последна промена на"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Последно ажурирање од"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Последно ажурирање на"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Пораки"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Пораки и историја на комуникација"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -577,7 +577,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
 msgid "Related"
-msgstr ""
+msgstr "Поврзано"
 
 #. module: connector
 #: code:addons/connector/related_action.py:48
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Непрочитани Пораки"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0

--- a/connector/i18n/mk.po
+++ b/connector/i18n/mk.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:44+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:27+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Macedonian (http://www.transifex.com/oca/OCA-connector-8-0/language/mk/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Активно"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/mn.po
+++ b/connector/i18n/mn.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-22 14:08+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:44+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Mongolian (http://www.transifex.com/oca/OCA-connector-8-0/language/mn/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Компани"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Төлөв"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/mn.po
+++ b/connector/i18n/mn.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:44+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:24+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Mongolian (http://www.transifex.com/oca/OCA-connector-8-0/language/mn/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Идэвхитэй"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/mn.po
+++ b/connector/i18n/mn.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-11-22 16:26+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Mongolian (http://www.transifex.com/oca/OCA-connector-8-0/language/mn/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
+"Language: mn\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr "Цуцлах"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Суваг"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Сувгууд"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Үүсгэгч"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Үүсгэсэн"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Бичлэгт хамгийн сүүлд илгээгдсэн зурвасын огноо."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Тодорхойлолт"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Дэлгэцийн Нэр"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Дагагчид"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Бүлэглэх"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Хэрэв тэмдэглэгдсэн бол таныг шинэ зурвасуудад анхаарал хандуулахыг шаардана."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Сүүлийн зурвасын огноо"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Сүүлийн засвар хийсэн огноо"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Сүүлийн засвар хийсэн"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Сүүлийн засвар хийсэн огноо"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Зурвасууд"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Зурвас болон харилцсан түүх"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Нэр"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -577,7 +577,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
 msgid "Related"
-msgstr ""
+msgstr "Холбогдсон"
 
 #. module: connector
 #: code:addons/connector/related_action.py:48
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Уншаагүй Зурвасууд"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "эсвэл"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/mn.po
+++ b/connector/i18n/mn.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-22 16:26+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-22 14:08+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Mongolian (http://www.transifex.com/oca/OCA-connector-8-0/language/mn/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Даалгавар"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/nb.po
+++ b/connector/i18n/nb.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-07 01:20+0000\n"
-"PO-Revision-Date: 2017-01-19 20:16+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:44+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Norwegian Bokmål (http://www.transifex.com/oca/OCA-connector-8-0/language/nb/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/nb.po
+++ b/connector/i18n/nb.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-11-22 16:25+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Norwegian Bokmål (http://www.transifex.com/oca/OCA-connector-8-0/language/nb/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
+"Language: nb\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr "Avbryt"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Kanal."
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Kanaler"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Opprettet av"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Opprettet den"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Dato for siste melding på denne posten."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Beskrivelse"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Visnings navn"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Følgere."
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Grupper etter"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Hvis det er merket nye meldinger så krever dette din oppmerksomhet."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Siste meldingsdato"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Sist oppdatert "
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Sist oppdatert av"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Sist oppdatert"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Meldinger."
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Meldinger og kommunikasjon historie."
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Navn"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Uleste meldinger."
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "eller"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/nb.po
+++ b/connector/i18n/nb.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:44+0000\n"
+"POT-Creation-Date: 2017-07-01 01:36+0000\n"
+"PO-Revision-Date: 2017-08-11 11:54+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Norwegian Bokmål (http://www.transifex.com/oca/OCA-connector-8-0/language/nb/)\n"
 "MIME-Version: 1.0\n"
@@ -668,7 +668,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr ""
+msgstr "Status"
 
 #. module: connector
 #: field:connector.checkpoint,state:0

--- a/connector/i18n/nb.po
+++ b/connector/i18n/nb.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-22 16:25+0000\n"
+"POT-Creation-Date: 2016-11-26 04:06+0000\n"
+"PO-Revision-Date: 2016-12-02 13:53+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Norwegian Bokmål (http://www.transifex.com/oca/OCA-connector-8-0/language/nb/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Aktiv"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -325,7 +325,7 @@ msgstr "Grupper etter"
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 msgid "Group By..."
-msgstr ""
+msgstr "Grupper etter ..."
 
 #. module: connector
 #: help:connector.checkpoint,message_summary:0

--- a/connector/i18n/nb.po
+++ b/connector/i18n/nb.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-26 04:06+0000\n"
-"PO-Revision-Date: 2016-12-02 13:53+0000\n"
+"POT-Creation-Date: 2017-01-07 01:20+0000\n"
+"PO-Revision-Date: 2017-01-19 20:16+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Norwegian Bokmål (http://www.transifex.com/oca/OCA-connector-8-0/language/nb/)\n"
 "MIME-Version: 1.0\n"
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Firma"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -532,7 +532,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Pending"
-msgstr ""
+msgstr "Venter"
 
 #. module: connector
 #: field:queue.job,func:0
@@ -542,7 +542,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,priority:0
 msgid "Priority"
-msgstr ""
+msgstr "Prioritet"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_queue

--- a/connector/i18n/nb_NO.po
+++ b/connector/i18n/nb_NO.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:44+0000\n"
+"POT-Creation-Date: 2017-07-01 01:36+0000\n"
+"PO-Revision-Date: 2017-08-11 12:01+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Norwegian Bokmål (Norway) (http://www.transifex.com/oca/OCA-connector-8-0/language/nb_NO/)\n"
 "MIME-Version: 1.0\n"
@@ -668,7 +668,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr ""
+msgstr "Stat"
 
 #. module: connector
 #: field:connector.checkpoint,state:0

--- a/connector/i18n/nb_NO.po
+++ b/connector/i18n/nb_NO.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-27 08:26+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:44+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Norwegian Bokmål (Norway) (http://www.transifex.com/oca/OCA-connector-8-0/language/nb_NO/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Firma"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/nb_NO.po
+++ b/connector/i18n/nb_NO.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-21 19:23+0000\n"
+"PO-Revision-Date: 2016-12-27 08:26+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: French (Canada) (http://www.transifex.com/oca/OCA-connector-8-0/language/fr_CA/)\n"
+"Language-Team: Norwegian Bokmål (Norway) (http://www.transifex.com/oca/OCA-connector-8-0/language/nb_NO/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: fr_CA\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: nb_NO\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Annuler"
+msgstr "Lukk"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Créé par"
+msgstr "Laget av"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Créé par"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Créé le"
+msgstr "Laget den"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Afficher le nom"
+msgstr "Vis navn"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -342,7 +342,7 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr "Identifiant"
+msgstr "ID"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
@@ -430,7 +430,7 @@ msgstr ""
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "Sist endret den"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Dernière mise à jour par"
+msgstr "Sist oppdatert av"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Dernière mise à jour par"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Dernière mise à jour le"
+msgstr "Sist oppdatert den"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -483,13 +483,13 @@ msgstr ""
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr "Modèle"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Nom"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,name:0

--- a/connector/i18n/nl.po
+++ b/connector/i18n/nl.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:41+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Dutch (http://www.transifex.com/oca/OCA-connector-8-0/language/nl/)\n"
 "MIME-Version: 1.0\n"
@@ -98,13 +98,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -153,7 +153,7 @@ msgstr "Klik op de"
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Bedrijf"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -526,7 +526,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -650,7 +650,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/nl.po
+++ b/connector/i18n/nl.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-09-17 18:43+0000\n"
+"PO-Revision-Date: 2016-11-25 14:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Dutch (http://www.transifex.com/oca/OCA-connector-8-0/language/nl/)\n"
 "MIME-Version: 1.0\n"
@@ -214,7 +214,7 @@ msgstr "Aanmaakdatum"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "Aangemaakt door"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -222,7 +222,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "Aangemaakt op"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -344,7 +344,7 @@ msgstr "Bevat de samenvatting van de chatter (aantal berichten,...). Deze samenv
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
@@ -440,7 +440,7 @@ msgstr "Laatst bijgewerkt op"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "Laatst bijgewerkt door"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -448,7 +448,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "Laatst bijgewerkt op"
 
 #. module: connector
 #: field:external.binding,sync_date:0

--- a/connector/i18n/nl_BE.po
+++ b/connector/i18n/nl_BE.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:24+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:55+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Dutch (Belgium) (http://www.transifex.com/oca/OCA-connector-8-0/language/nl_BE/)\n"
 "MIME-Version: 1.0\n"
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr ""
+msgstr "Kanaal"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Kanalen"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "Gemaakt door"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "Gemaakt op"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "Datum laatste bericht voor dit record."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr ""
+msgstr "Schermnaam"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr ""
+msgstr "Volgers"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "Groeperen op"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr ""
+msgstr "Als dit is ingeschakeld, zijn er nieuwe berichten die uw aandacht vragen."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "Datum laatste bericht"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr ""
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "Laatst Aangepast op"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "Laatst bijgewerkt door"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "Laatst bijgewerkt op"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr ""
+msgstr "Berichten"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr ""
+msgstr "Berichten en communicatiehistoriek"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Naam:"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr ""
+msgstr "Ongelezen berichten"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "of"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/nl_BE.po
+++ b/connector/i18n/nl_BE.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:39+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:26+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Dutch (Belgium) (http://www.transifex.com/oca/OCA-connector-8-0/language/nl_BE/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Actief"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/nl_BE.po
+++ b/connector/i18n/nl_BE.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:55+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:39+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Dutch (Belgium) (http://www.transifex.com/oca/OCA-connector-8-0/language/nl_BE/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Bedrijf"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/nl_NL.po
+++ b/connector/i18n/nl_NL.po
@@ -1,0 +1,788 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: connector (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 00:46+0000\n"
+"PO-Revision-Date: 2017-06-30 08:53+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
+"Language-Team: Dutch (Netherlands) (http://www.transifex.com/oca/OCA-connector-8-0/language/nl_NL/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: nl_NL\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: connector
+#: model:ir.actions.act_window,help:connector.action_connector_checkpoint
+msgid ""
+"<p>No record to check.</p>\n"
+"                <p> When a connector imports new records which have\n"
+"                    configuration or reviews to do manually, they\n"
+"                    will appear in this list.  Once a record has been\n"
+"                    checked, click on the 'Reviewed' button.  </p>\n"
+"                <p>The connectors list the new records to verify\n"
+"                    based on their type.  Only some need a manual\n"
+"                    review.</p>\n"
+"            "
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/checkpoint/checkpoint.py:136
+#, python-format
+msgid "A %s needs a review."
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,module_portal:0
+msgid "Activate the customer portal"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,active:0
+msgid "Active"
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,alias_domain:0
+msgid "Alias Domain"
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,module_share:0
+msgid "Allow documents sharing"
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,module_google_calendar:0
+msgid "Allow the users to synchronize their calendar  with Google Calendar"
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,module_base_import:0
+msgid "Allow users to import data from CSV files"
+msgstr ""
+
+#. module: connector
+#: view:connector.config.settings:connector.view_connector_config_settings
+msgid "Apply"
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,module_google_drive:0
+msgid "Attach Google documents to any record"
+msgstr ""
+
+#. module: connector
+#: view:connector.config.settings:connector.view_connector_config_settings
+msgid "Backends"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint.review:connector.view_connector_checkpoint_review
+#: view:connector.config.settings:connector.view_connector_config_settings
+#: view:queue.requeue.job:connector.view_requeue_job
+msgid "Cancel"
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/queue/job.py:619
+#, python-format
+msgid "Canceled. Nothing to do."
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/queue/model.py:462
+#, python-format
+msgid "Cannot change the root channel"
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/queue/model.py:469
+#, python-format
+msgid "Cannot remove the root channel"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search field:queue.job,channel:0
+#: view:queue.job.function:connector.view_queue_job_function_search
+#: field:queue.job.function,channel_id:0
+msgid "Channel"
+msgstr ""
+
+#. module: connector
+#: sql_constraint:queue.job.channel:0
+msgid "Channel complete name must be unique"
+msgstr ""
+
+#. module: connector
+#: model:ir.actions.act_window,name:connector.action_queue_job_channel
+#: model:ir.ui.menu,name:connector.menu_queue_job_channel
+#: view:queue.job.channel:connector.view_queue_job_channel_form
+#: view:queue.job.channel:connector.view_queue_job_channel_search
+#: view:queue.job.channel:connector.view_queue_job_channel_tree
+msgid "Channels"
+msgstr ""
+
+#. module: connector
+#: model:ir.ui.menu,name:connector.menu_checkpoint
+msgid "Checkpoint"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint.review,checkpoint_ids:0
+msgid "Checkpoints"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_connector_checkpoint_review
+msgid "Checkpoints Review"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint:connector.view_connector_checkpoint_form
+msgid "Click on the"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,company_id:0
+msgid "Company"
+msgstr ""
+
+#. module: connector
+#: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
+msgid "Complete Name"
+msgstr ""
+
+#. module: connector
+#: view:connector.config.settings:connector.view_connector_config_settings
+#: model:ir.actions.act_window,name:connector.action_connector_config_settings
+msgid "Configure Connector"
+msgstr ""
+
+#. module: connector
+#: model:ir.module.category,name:connector.module_category_connector
+#: model:ir.ui.menu,name:connector.menu_connector_config_settings
+msgid "Connector"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_connector_backend
+msgid "Connector Backend"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint:connector.view_connector_checkpoint_form
+#: view:connector.checkpoint:connector.view_connector_checkpoint_search
+#: view:connector.checkpoint:connector.view_connector_checkpoint_tree
+#: model:ir.actions.act_window,name:connector.action_connector_checkpoint
+#: model:ir.model,name:connector.model_connector_checkpoint
+msgid "Connector Checkpoint"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_connector_config_settings
+msgid "Connector Configuration"
+msgstr ""
+
+#. module: connector
+#: model:res.groups,name:connector.group_connector_manager
+msgid "Connector Manager"
+msgstr ""
+
+#. module: connector
+#: model:ir.ui.menu,name:connector.menu_connector
+#: model:ir.ui.menu,name:connector.menu_connector_root
+#: view:res.partner:connector.view_partner_connector_form
+msgid "Connectors"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,date_created:0
+msgid "Created Date"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,create_uid:0
+#: field:connector.checkpoint.review,create_uid:0
+#: field:connector.config.settings,create_uid:0
+#: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
+msgid "Created by"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,create_date:0
+#: field:connector.checkpoint.review,create_date:0
+#: field:connector.config.settings,create_date:0
+#: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
+msgid "Created on"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,retry:0
+msgid "Current try"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_form
+msgid "Current try / max. retries"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,date_done:0
+msgid "Date Done"
+msgstr ""
+
+#. module: connector
+#: help:connector.checkpoint,message_last_post:0
+#: help:queue.job,message_last_post:0
+msgid "Date of the last message posted on the record."
+msgstr ""
+
+#. module: connector
+#: field:queue.job,name:0
+msgid "Description"
+msgstr ""
+
+#. module: connector
+#: field:connector.backend,display_name:0
+#: field:connector.checkpoint,display_name:0
+#: field:connector.checkpoint.review,display_name:0
+#: field:connector.config.settings,display_name:0
+#: field:external.binding,display_name:0 field:queue.job,display_name:0
+#: field:queue.job.channel,display_name:0
+#: field:queue.job.function,display_name:0
+#: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
+msgid "Display Name"
+msgstr "Weergavenaam"
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
+msgid "Done"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,date_enqueued:0
+msgid "Enqueue Time"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
+msgid "Enqueued"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,exc_info:0
+msgid "Exception Info"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_form
+msgid "Exception Information"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,eta:0
+msgid "Execute only after"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_external_binding
+msgid "External Binding (abstract)"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
+msgid "Failed"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,message_follower_ids:0
+#: field:queue.job,message_follower_ids:0
+msgid "Followers"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,func_name:0
+msgid "Func name"
+msgstr ""
+
+#. module: connector
+#: help:connector.config.settings,module_portal:0
+msgid "Give your customers access to their documents."
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search
+#: view:queue.job.function:connector.view_queue_job_function_search
+msgid "Group By"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint:connector.view_connector_checkpoint_search
+msgid "Group By..."
+msgstr ""
+
+#. module: connector
+#: help:connector.checkpoint,message_summary:0
+#: help:queue.job,message_summary:0
+msgid ""
+"Holds the Chatter summary (number of messages, ...). This summary is "
+"directly in html format in order to be inserted in kanban views."
+msgstr ""
+
+#. module: connector
+#: field:connector.backend,id:0 field:connector.checkpoint,id:0
+#: field:connector.checkpoint.review,id:0 field:connector.config.settings,id:0
+#: field:external.binding,id:0 field:queue.job,id:0
+#: field:queue.job.channel,id:0 field:queue.job.function,id:0
+#: field:queue.requeue.job,id:0 field:queue.worker,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: connector
+#: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
+msgid "If checked new messages require your attention."
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_form
+msgid "If the max. retries is 0, the number of retries is infinite."
+msgstr ""
+
+#. module: connector
+#: help:connector.config.settings,alias_domain:0
+msgid ""
+"If you have setup a catch-all email domain redirected to the Odoo server, "
+"enter the domain name here."
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,backend_id:0
+msgid "Imported from"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,message_is_follower:0
+#: field:queue.job,message_is_follower:0
+msgid "Is a Follower"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_queue_job_channel
+msgid "Job Channels"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search
+#: field:queue.job,job_function_id:0
+msgid "Job Function"
+msgstr ""
+
+#. module: connector
+#: model:ir.actions.act_window,name:connector.action_queue_job_function
+#: model:ir.model,name:connector.model_queue_job_function
+#: model:ir.ui.menu,name:connector.menu_queue_job_function
+#: field:queue.job.channel,job_function_ids:0
+#: view:queue.job.function:connector.view_queue_job_function_form
+#: view:queue.job.function:connector.view_queue_job_function_search
+#: view:queue.job.function:connector.view_queue_job_function_tree
+msgid "Job Functions"
+msgstr ""
+
+#. module: connector
+#: model:mail.message.subtype,name:connector.mt_job_failed
+msgid "Job failed"
+msgstr ""
+
+#. module: connector
+#: model:ir.actions.act_window,name:connector.action_queue_job
+#: model:ir.ui.menu,name:connector.menu_queue_job
+#: view:queue.job:connector.view_queue_job_form
+#: view:queue.job:connector.view_queue_job_search
+#: view:queue.job:connector.view_queue_job_tree
+#: field:queue.requeue.job,job_ids:0 field:queue.worker,job_ids:0
+msgid "Jobs"
+msgstr ""
+
+#. module: connector
+#: field:queue.worker,date_alive:0
+msgid "Last Alive Check"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,message_last_post:0
+#: field:queue.job,message_last_post:0
+msgid "Last Message Date"
+msgstr ""
+
+#. module: connector
+#: field:connector.backend,__last_update:0
+#: field:connector.checkpoint,__last_update:0
+#: field:connector.checkpoint.review,__last_update:0
+#: field:connector.config.settings,__last_update:0
+#: field:external.binding,__last_update:0 field:queue.job,__last_update:0
+#: field:queue.job.channel,__last_update:0
+#: field:queue.job.function,__last_update:0
+#: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
+msgid "Last Modified on"
+msgstr "Laatst gewijzigd op"
+
+#. module: connector
+#: field:connector.checkpoint,write_uid:0
+#: field:connector.checkpoint.review,write_uid:0
+#: field:connector.config.settings,write_uid:0
+#: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
+msgid "Last Updated by"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,write_date:0
+#: field:connector.checkpoint.review,write_date:0
+#: field:connector.config.settings,write_date:0
+#: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
+msgid "Last Updated on"
+msgstr ""
+
+#. module: connector
+#: field:external.binding,sync_date:0
+msgid "Last synchronization date"
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,module_multi_company:0
+msgid "Manage multiple companies"
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/queue/model.py:141
+#, python-format
+msgid "Manually set to done by %s"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,max_retries:0
+msgid "Max. retries"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
+msgid "Messages"
+msgstr ""
+
+#. module: connector
+#: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
+msgid "Messages and communication history"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint:connector.view_connector_checkpoint_search
+#: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
+msgid "Model"
+msgstr ""
+
+#. module: connector
+#: field:connector.backend,name:0 field:queue.job.channel,name:0
+#: field:queue.job.function,name:0
+msgid "Name"
+msgstr ""
+
+#. module: connector
+#: help:connector.checkpoint,name:0
+msgid "Name of the record to review"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint:connector.view_connector_checkpoint_search
+#: selection:connector.checkpoint,state:0
+msgid "Need Review"
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/queue/model.py:117
+#, python-format
+msgid "No action available for this job"
+msgstr ""
+
+#. module: connector
+#: model:ir.actions.client,name:connector.action_client_connector_menu
+msgid "Open Connector Menu"
+msgstr ""
+
+#. module: connector
+#: field:queue.worker,pid:0
+msgid "PID"
+msgstr ""
+
+#. module: connector
+#: field:queue.job.channel,parent_id:0
+msgid "Parent Channel"
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/queue/model.py:454
+#, python-format
+msgid "Parent channel required."
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
+msgid "Pending"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,func:0
+msgid "Pickled Function"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,priority:0
+msgid "Priority"
+msgstr ""
+
+#. module: connector
+#: model:ir.ui.menu,name:connector.menu_queue
+msgid "Queue"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_queue_job
+msgid "Queue Job"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_queue_worker
+msgid "Queue Worker"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,record:0
+msgid "Record"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,record_id:0
+msgid "Record ID"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,name:0
+msgid "Record Name"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_form
+msgid "Related"
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/related_action.py:48
+#, python-format
+msgid "Related Record"
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,font:0
+msgid "Report Font"
+msgstr ""
+
+#. module: connector
+#: view:queue.requeue.job:connector.view_requeue_job
+msgid "Requeue"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_form
+msgid "Requeue Job"
+msgstr ""
+
+#. module: connector
+#: model:ir.actions.act_window,name:connector.action_requeue_job
+#: view:queue.requeue.job:connector.view_requeue_job
+msgid "Requeue Jobs"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_form field:queue.job,result:0
+msgid "Result"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint.review:connector.view_connector_checkpoint_review
+#: model:ir.actions.act_window,name:connector.action_connector_checkpoint_review
+msgid "Review Checkpoints"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint:connector.view_connector_checkpoint_form
+#: view:connector.checkpoint:connector.view_connector_checkpoint_search
+#: view:connector.checkpoint:connector.view_connector_checkpoint_tree
+#: selection:connector.checkpoint,state:0
+msgid "Reviewed"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint.review:connector.view_connector_checkpoint_review
+msgid "Set as reviewed"
+msgstr ""
+
+#. module: connector
+#: help:connector.config.settings,font:0
+msgid ""
+"Set the font into the report header, it will be used as default font in the "
+"RML reports of the user company"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_form
+msgid "Set to 'Done'"
+msgstr ""
+
+#. module: connector
+#: help:connector.config.settings,module_share:0
+msgid "Share or embbed any screen of Odoo."
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/queue/model.py:192
+#, python-format
+msgid ""
+"Something bad happened during the execution of the job. More details in the "
+"'Exception Information' section."
+msgstr ""
+
+#. module: connector
+#: field:queue.job,date_started:0 field:queue.worker,date_start:0
+msgid "Start Date"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
+msgid "Started"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
+msgid "State"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,state:0
+msgid "Status"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,message_summary:0
+#: field:queue.job,message_summary:0
+msgid "Summary"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,func_string:0
+msgid "Task"
+msgstr ""
+
+#. module: connector
+#: help:queue.job,max_retries:0
+msgid ""
+"The job will fail if the number of tries reach the max. retries.\n"
+"Retries are infinite when empty."
+msgstr ""
+
+#. module: connector
+#: help:connector.checkpoint,backend_id:0
+msgid "The record has been imported from this backend"
+msgstr ""
+
+#. module: connector
+#: help:connector.checkpoint,record:0
+msgid "The record to review."
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint.review:connector.view_connector_checkpoint_review
+msgid "The selected checkpoints will be set as reviewed."
+msgstr ""
+
+#. module: connector
+#: view:queue.requeue.job:connector.view_requeue_job
+msgid "The selected jobs will be requeued."
+msgstr ""
+
+#. module: connector
+#: help:connector.config.settings,module_google_calendar:0
+msgid "This installs the module google_calendar."
+msgstr ""
+
+#. module: connector
+#: help:connector.config.settings,module_google_drive:0
+msgid "This installs the module google_docs."
+msgstr ""
+
+#. module: connector
+#: field:queue.job,uuid:0 field:queue.worker,uuid:0
+msgid "UUID"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,message_unread:0
+#: field:queue.job,message_unread:0
+msgid "Unread Messages"
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,module_auth_oauth:0
+msgid ""
+"Use external authentication providers, sign in with google, facebook, ..."
+msgstr ""
+
+#. module: connector
+#: field:queue.job,user_id:0
+msgid "User ID"
+msgstr ""
+
+#. module: connector
+#: field:connector.backend,version:0
+msgid "Version"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_queue_requeue_job
+msgid "Wizard to requeue a selection of jobs"
+msgstr ""
+
+#. module: connector
+#: help:connector.config.settings,module_multi_company:0
+msgid ""
+"Work in multi-company environments, with appropriate security access between companies.\n"
+"-This installs the module multi_company."
+msgstr ""
+
+#. module: connector
+#: field:queue.job,worker_id:0
+#: view:queue.worker:connector.view_queue_worker_form
+#: view:queue.worker:connector.view_queue_worker_tree
+msgid "Worker"
+msgstr ""
+
+#. module: connector
+#: model:ir.actions.act_window,name:connector.action_queue_worker
+#: model:ir.ui.menu,name:connector.menu_queue_worker
+msgid "Workers"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint.review:connector.view_connector_checkpoint_review
+#: view:connector.config.settings:connector.view_connector_config_settings
+#: view:queue.requeue.job:connector.view_requeue_job
+msgid "or"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint:connector.view_connector_checkpoint_form
+msgid "to verify it:"
+msgstr ""

--- a/connector/i18n/nl_NL.po
+++ b/connector/i18n/nl_NL.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-24 00:46+0000\n"
-"PO-Revision-Date: 2017-06-30 08:53+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-29 08:01+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Dutch (Netherlands) (http://www.transifex.com/oca/OCA-connector-8-0/language/nl_NL/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Verwijderen"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "Aangemaakt door"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "Aangemaakt op"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -246,7 +246,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "Omschrijving"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -438,7 +438,7 @@ msgstr "Laatst gewijzigd op"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "Laatst bijgewerkt door"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "Laatst bijgewerkt op"
 
 #. module: connector
 #: field:external.binding,sync_date:0

--- a/connector/i18n/pl.po
+++ b/connector/i18n/pl.po
@@ -7,15 +7,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-23 08:32+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:43+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Polish (http://www.transifex.com/oca/OCA-connector-8-0/language/pl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Language: pl\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>=14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Firma"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/pl.po
+++ b/connector/i18n/pl.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:55+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-23 08:32+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Polish (http://www.transifex.com/oca/OCA-connector-8-0/language/pl/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Zadanie"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/pl.po
+++ b/connector/i18n/pl.po
@@ -7,15 +7,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:43+0000\n"
+"POT-Creation-Date: 2017-07-01 01:36+0000\n"
+"PO-Revision-Date: 2017-08-11 11:55+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Polish (http://www.transifex.com/oca/OCA-connector-8-0/language/pl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Language: pl\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>=14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -668,7 +668,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr ""
+msgstr "Stan"
 
 #. module: connector
 #: field:connector.checkpoint,state:0

--- a/connector/i18n/pl.po
+++ b/connector/i18n/pl.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:25+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:55+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Polish (http://www.transifex.com/oca/OCA-connector-8-0/language/pl/)\n"
 "MIME-Version: 1.0\n"
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr ""
+msgstr "Kanał"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Kanały"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "Utworzone przez"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "Utworzono"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "Data ostatniej wiadomości w rekordzie."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "Opis"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr ""
+msgstr "Wyświetlana nazwa "
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr ""
+msgstr "Obserwatorzy"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "Pogrupuj wg"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr ""
+msgstr "Jeśli zaznaczone, to wiadomość wymaga twojej uwagi"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "Data ostatniej wiadomości"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr ""
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "Ostatnio modyfikowano"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "Ostatnio modyfikowane przez"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "Ostatnia zmiana"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr ""
+msgstr "Wiadomosći"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr ""
+msgstr "Wiadomości i historia komunikacji"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Nazwa"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -577,7 +577,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
 msgid "Related"
-msgstr ""
+msgstr "Powiązane"
 
 #. module: connector
 #: code:addons/connector/related_action.py:48
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr ""
+msgstr "Nieprzeczytane wiadomości"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "lub"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/pt.po
+++ b/connector/i18n/pt.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-07 01:20+0000\n"
-"PO-Revision-Date: 2017-01-13 09:26+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:42+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Portuguese (http://www.transifex.com/oca/OCA-connector-8-0/language/pt/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Estado"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/pt.po
+++ b/connector/i18n/pt.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:42+0000\n"
+"POT-Creation-Date: 2017-07-01 01:36+0000\n"
+"PO-Revision-Date: 2017-08-03 13:34+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Portuguese (http://www.transifex.com/oca/OCA-connector-8-0/language/pt/)\n"
 "MIME-Version: 1.0\n"
@@ -668,7 +668,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr ""
+msgstr "Estado"
 
 #. module: connector
 #: field:connector.checkpoint,state:0

--- a/connector/i18n/pt.po
+++ b/connector/i18n/pt.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:27+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:58+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Portuguese (http://www.transifex.com/oca/OCA-connector-8-0/language/pt/)\n"
 "MIME-Version: 1.0\n"
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr ""
+msgstr "Nome"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "Agrupar por"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -430,7 +430,7 @@ msgstr ""
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "Modificado a última vez por"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -483,13 +483,13 @@ msgstr ""
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr ""
+msgstr "Modelo"
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Nome"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "ou"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/pt.po
+++ b/connector/i18n/pt.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:58+0000\n"
+"POT-Creation-Date: 2016-11-26 04:06+0000\n"
+"PO-Revision-Date: 2016-12-12 11:41+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Portuguese (http://www.transifex.com/oca/OCA-connector-8-0/language/pt/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Ativo"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Empresa"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0

--- a/connector/i18n/pt.po
+++ b/connector/i18n/pt.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-22 14:05+0000\n"
+"POT-Creation-Date: 2017-01-07 01:20+0000\n"
+"PO-Revision-Date: 2017-01-13 09:26+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Portuguese (http://www.transifex.com/oca/OCA-connector-8-0/language/pt/)\n"
 "MIME-Version: 1.0\n"
@@ -246,7 +246,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "Descrição"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -263,7 +263,7 @@ msgstr "Nome"
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr ""
+msgstr "Concluído"
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -532,7 +532,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Pending"
-msgstr ""
+msgstr "Pendente"
 
 #. module: connector
 #: field:queue.job,func:0

--- a/connector/i18n/pt.po
+++ b/connector/i18n/pt.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-26 04:06+0000\n"
-"PO-Revision-Date: 2016-12-12 11:41+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-22 14:05+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Portuguese (http://www.transifex.com/oca/OCA-connector-8-0/language/pt/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Tarefa"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/pt_BR.po
+++ b/connector/i18n/pt_BR.po
@@ -6,13 +6,14 @@
 # danimaribeiro <danimaribeiro@gmail.com>, 2015
 # danimaribeiro <danimaribeiro@gmail.com>, 2015
 # Hotellook, 2014
+# Rodrigo de Almeida Sottomaior Macedo <rmsolucoeseminformatic4@gmail.com>, 2017
 msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 22:46+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
+"POT-Creation-Date: 2017-05-01 16:08+0000\n"
+"PO-Revision-Date: 2017-05-18 19:18+0000\n"
+"Last-Translator: Rodrigo de Almeida Sottomaior Macedo <rmsolucoeseminformatic4@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/oca/OCA-connector-8-0/language/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -497,7 +498,7 @@ msgstr "Nome"
 #. module: connector
 #: help:connector.checkpoint,name:0
 msgid "Name of the record to review"
-msgstr ""
+msgstr "Nome do registro a ser revisado"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -565,7 +566,7 @@ msgstr "Fila de trabalho"
 #. module: connector
 #: field:connector.checkpoint,record:0
 msgid "Record"
-msgstr ""
+msgstr "Registro"
 
 #. module: connector
 #: field:connector.checkpoint,record_id:0
@@ -575,7 +576,7 @@ msgstr "ID do registro"
 #. module: connector
 #: field:connector.checkpoint,name:0
 msgid "Record Name"
-msgstr ""
+msgstr "Nome de Registro"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -704,7 +705,7 @@ msgstr "O registro foi importado deste backend"
 #. module: connector
 #: help:connector.checkpoint,record:0
 msgid "The record to review."
-msgstr ""
+msgstr "O registro a ser revisado."
 
 #. module: connector
 #: view:connector.checkpoint.review:connector.view_connector_checkpoint_review

--- a/connector/i18n/pt_BR.po
+++ b/connector/i18n/pt_BR.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-04 09:43+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 22:46+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/oca/OCA-connector-8-0/language/pt_BR/)\n"
 "MIME-Version: 1.0\n"
@@ -99,13 +99,13 @@ msgid "Canceled. Nothing to do."
 msgstr "Cancelado. Nada a se fazer"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr "Não pode modificar o canal principal"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr "Não pode remover o canal principal"
@@ -527,7 +527,7 @@ msgid "Parent Channel"
 msgstr "Canal pai"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr "Canal pai é obrigatório"
@@ -651,7 +651,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr "Compartilhe ou incorpore qualquer tela do Odoo"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/pt_PT.po
+++ b/connector/i18n/pt_PT.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:55+0000\n"
+"POT-Creation-Date: 2016-11-26 04:06+0000\n"
+"PO-Revision-Date: 2016-12-15 10:08+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Portuguese (Portugal) (http://www.transifex.com/oca/OCA-connector-8-0/language/pt_PT/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Ativo"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Empresa"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -246,7 +246,7 @@ msgstr "Data da última mensagem registada."
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "Descrição"
 
 #. module: connector
 #: field:connector.backend,display_name:0

--- a/connector/i18n/pt_PT.po
+++ b/connector/i18n/pt_PT.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-26 04:06+0000\n"
-"PO-Revision-Date: 2016-12-15 10:08+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-23 08:33+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Portuguese (Portugal) (http://www.transifex.com/oca/OCA-connector-8-0/language/pt_PT/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr "Resumo"
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Tarefa"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/pt_PT.po
+++ b/connector/i18n/pt_PT.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-07 01:20+0000\n"
-"PO-Revision-Date: 2017-01-13 09:26+0000\n"
+"POT-Creation-Date: 2017-07-01 01:36+0000\n"
+"PO-Revision-Date: 2017-08-11 12:25+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Portuguese (Portugal) (http://www.transifex.com/oca/OCA-connector-8-0/language/pt_PT/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -668,7 +668,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr ""
+msgstr "Estado"
 
 #. module: connector
 #: field:connector.checkpoint,state:0

--- a/connector/i18n/pt_PT.po
+++ b/connector/i18n/pt_PT.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-13 11:38+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:55+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Portuguese (Portugal) (http://www.transifex.com/oca/OCA-connector-8-0/language/pt_PT/)\n"
 "MIME-Version: 1.0\n"
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr ""
+msgstr "Nome a Apresentar"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -430,7 +430,7 @@ msgstr "Data da Última Mensagem"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "Última Modificação Em"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -483,13 +483,13 @@ msgstr "História das mensagens e comunicações"
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr ""
+msgstr "Modelo"
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Nome"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "ou"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/ro.po
+++ b/connector/i18n/ro.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:42+0000\n"
+"POT-Creation-Date: 2017-07-01 01:36+0000\n"
+"PO-Revision-Date: 2017-08-11 11:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Romanian (http://www.transifex.com/oca/OCA-connector-8-0/language/ro/)\n"
 "MIME-Version: 1.0\n"
@@ -493,7 +493,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Nume"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -672,7 +672,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr ""
+msgstr "Județ"
 
 #. module: connector
 #: field:connector.checkpoint,state:0

--- a/connector/i18n/ro.po
+++ b/connector/i18n/ro.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-27 08:24+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:42+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Romanian (http://www.transifex.com/oca/OCA-connector-8-0/language/ro/)\n"
 "MIME-Version: 1.0\n"
@@ -100,13 +100,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -155,7 +155,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Companie"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -528,7 +528,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -652,7 +652,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -677,7 +677,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Stare"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/ro.po
+++ b/connector/i18n/ro.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-22 14:05+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:24+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Romanian (http://www.transifex.com/oca/OCA-connector-8-0/language/ro/)\n"
 "MIME-Version: 1.0\n"
@@ -216,7 +216,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "Creat de"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -224,7 +224,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "Creat la"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -262,7 +262,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr ""
+msgstr "Nume Afişat"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -346,7 +346,7 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
@@ -434,7 +434,7 @@ msgstr ""
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "Ultima actualizare în"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -442,7 +442,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "Ultima actualizare făcută de"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -450,7 +450,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "Ultima actualizare la"
 
 #. module: connector
 #: field:external.binding,sync_date:0

--- a/connector/i18n/ro.po
+++ b/connector/i18n/ro.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:24+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:55+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Romanian (http://www.transifex.com/oca/OCA-connector-8-0/language/ro/)\n"
 "MIME-Version: 1.0\n"
@@ -784,7 +784,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "sau"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/ro.po
+++ b/connector/i18n/ro.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:55+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-22 14:05+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Romanian (http://www.transifex.com/oca/OCA-connector-8-0/language/ro/)\n"
 "MIME-Version: 1.0\n"
@@ -688,7 +688,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Sarcina"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/ru.po
+++ b/connector/i18n/ru.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-27 08:22+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:40+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Russian (http://www.transifex.com/oca/OCA-connector-8-0/language/ru/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Компания"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Статус"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/ru.po
+++ b/connector/i18n/ru.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-04 09:42+0000\n"
+"PO-Revision-Date: 2016-11-25 14:56+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Russian (http://www.transifex.com/oca/OCA-connector-8-0/language/ru/)\n"
 "MIME-Version: 1.0\n"
@@ -483,13 +483,13 @@ msgstr ""
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr ""
+msgstr "Модель"
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Название"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "или"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/ru.po
+++ b/connector/i18n/ru.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:40+0000\n"
+"POT-Creation-Date: 2017-05-01 16:08+0000\n"
+"PO-Revision-Date: 2017-05-11 14:11+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Russian (http://www.transifex.com/oca/OCA-connector-8-0/language/ru/)\n"
 "MIME-Version: 1.0\n"
@@ -263,7 +263,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr ""
+msgstr "Завершен"
 
 #. module: connector
 #: field:queue.job,date_enqueued:0

--- a/connector/i18n/ru.po
+++ b/connector/i18n/ru.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:56+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:22+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Russian (http://www.transifex.com/oca/OCA-connector-8-0/language/ru/)\n"
 "MIME-Version: 1.0\n"
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "Создано"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "Создан"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -342,7 +342,7 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "Последний раз обновлено"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "Последний раз обновлено"
 
 #. module: connector
 #: field:external.binding,sync_date:0

--- a/connector/i18n/ru.po
+++ b/connector/i18n/ru.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-01 16:08+0000\n"
-"PO-Revision-Date: 2017-05-11 14:11+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:18+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Russian (http://www.transifex.com/oca/OCA-connector-8-0/language/ru/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Активное"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/sk.po
+++ b/connector/i18n/sk.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-27 08:26+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:42+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Slovak (http://www.transifex.com/oca/OCA-connector-8-0/language/sk/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Spoločnosť"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/sk.po
+++ b/connector/i18n/sk.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-22 20:40+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:26+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Slovak (http://www.transifex.com/oca/OCA-connector-8-0/language/sk/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Zrušiť"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/sk.po
+++ b/connector/i18n/sk.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-22 16:25+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-22 20:40+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Slovak (http://www.transifex.com/oca/OCA-connector-8-0/language/sk/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Aktívne"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -263,7 +263,7 @@ msgstr "Zobraziť meno"
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr ""
+msgstr "Hotovo"
 
 #. module: connector
 #: field:queue.job,date_enqueued:0

--- a/connector/i18n/sk.po
+++ b/connector/i18n/sk.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-11-22 16:25+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Slovak (http://www.transifex.com/oca/OCA-connector-8-0/language/sk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: sk\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Kanál"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Kanály"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Vytvoril"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Vytvorené"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Dátum poslednej správy zaslanej záznamu."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Popis"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Zobraziť meno"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Odberatelia"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Zoskupiť podľa"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Ak zaškrtnuté, nové správy vyžadujú vašu pozornosť."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Dátum poslednej správy"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Posledná modifikácia"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Naposledy upravoval"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Naposledy upravované"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Správy"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Správa a história komunikácie"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Meno"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -577,7 +577,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
 msgid "Related"
-msgstr ""
+msgstr "Súvisiace"
 
 #. module: connector
 #: code:addons/connector/related_action.py:48
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Neprečítané správy"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "alebo"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/sl.po
+++ b/connector/i18n/sl.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-15 18:48+0000\n"
-"PO-Revision-Date: 2016-08-16 07:57+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:44+0000\n"
 "Last-Translator: Matjaž Mozetič <m.mozetic@matmoz.si>\n"
 "Language-Team: Slovenian (http://www.transifex.com/oca/OCA-connector-8-0/language/sl/)\n"
 "MIME-Version: 1.0\n"
@@ -97,13 +97,13 @@ msgid "Canceled. Nothing to do."
 msgstr "Preklicano. Ni opravkov."
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr "Korenskega kanala ni mogoče spreminjati"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr "Korenskega kanala ni mogoče odstraniti"
@@ -525,7 +525,7 @@ msgid "Parent Channel"
 msgstr "Nadrejeni kanal"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr "Zahteva se nadrejeni kanal."
@@ -649,7 +649,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr "Souporaba ali vgradnja kateregakoli zaslona Odoo"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/sr.po
+++ b/connector/i18n/sr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-11 09:49+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:25+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Serbian (http://www.transifex.com/oca/OCA-connector-8-0/language/sr/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Otkaži"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/sr.po
+++ b/connector/i18n/sr.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-10-11 09:49+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Serbian (http://www.transifex.com/oca/OCA-connector-8-0/language/sr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: sr\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Kreiran"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr ""
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Opis"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Grupiši po"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr ""
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Poruke"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Ime"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/sr@latin.po
+++ b/connector/i18n/sr@latin.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-11-22 16:24+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Serbian (Latin) (http://www.transifex.com/oca/OCA-connector-8-0/language/sr@latin/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: sr@latin\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr "Otkaži"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Kanal"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Kreirao"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Kreiran"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Datum zadnje poslate poruke na slog."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Opis"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Ime za prikaz"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Pratioci"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Grupisano po"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Ako je označeno, nove poruke zahtjevaju pažnju"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Datum zadnje poruke"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Zadnja izmjena"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Zadnja izmjena"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Zadnja izmjena"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Poruke"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Poruke i istorija komunikacije"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Ime:"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Nepročitane poruke"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "ili"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/sr@latin.po
+++ b/connector/i18n/sr@latin.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-22 16:24+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:27+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Serbian (Latin) (http://www.transifex.com/oca/OCA-connector-8-0/language/sr@latin/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Aktivno"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/sv.po
+++ b/connector/i18n/sv.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-11-22 16:25+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Swedish (http://www.transifex.com/oca/OCA-connector-8-0/language/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
+"Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: connector
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr "Avbryt"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "Kanal"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Kanaler"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Skapad av"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Skapad den"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Datum för senast publicerade meddelandet i loggen."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Beskrivning"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Visa namn"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Följare"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Gruppera efter"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Om ikryssad nya meddelanden som kräver din uppmärksamhet"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Senast meddelandedatum"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Senast redigerad"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Senast uppdaterad av"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Senast uppdaterad"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Meddelanden"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Meddelande- och kommunikationshistorik"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Namn"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Olästa meddelanden"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "eller"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/sv.po
+++ b/connector/i18n/sv.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-22 16:25+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-22 14:08+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Swedish (http://www.transifex.com/oca/OCA-connector-8-0/language/sv/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Uppgift"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/sv.po
+++ b/connector/i18n/sv.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-01 01:36+0000\n"
-"PO-Revision-Date: 2017-08-11 11:58+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:26+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Swedish (http://www.transifex.com/oca/OCA-connector-8-0/language/sv/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Aktiv"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/sv.po
+++ b/connector/i18n/sv.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-22 14:08+0000\n"
+"POT-Creation-Date: 2017-01-07 01:20+0000\n"
+"PO-Revision-Date: 2017-01-19 20:16+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Swedish (http://www.transifex.com/oca/OCA-connector-8-0/language/sv/)\n"
 "MIME-Version: 1.0\n"
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Företag"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -325,7 +325,7 @@ msgstr "Gruppera efter"
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 msgid "Group By..."
-msgstr ""
+msgstr "Gruppera efter..."
 
 #. module: connector
 #: help:connector.checkpoint,message_summary:0
@@ -532,7 +532,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Pending"
-msgstr ""
+msgstr "Pågående"
 
 #. module: connector
 #: field:queue.job,func:0
@@ -542,7 +542,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,priority:0
 msgid "Priority"
-msgstr ""
+msgstr "Prioritet"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_queue

--- a/connector/i18n/sv.po
+++ b/connector/i18n/sv.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-07 01:20+0000\n"
-"PO-Revision-Date: 2017-01-19 20:16+0000\n"
+"POT-Creation-Date: 2017-07-01 01:36+0000\n"
+"PO-Revision-Date: 2017-08-11 11:58+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Swedish (http://www.transifex.com/oca/OCA-connector-8-0/language/sv/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -668,7 +668,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr ""
+msgstr "Status"
 
 #. module: connector
 #: field:connector.checkpoint,state:0

--- a/connector/i18n/th.po
+++ b/connector/i18n/th.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:44+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:21+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Thai (http://www.transifex.com/oca/OCA-connector-8-0/language/th/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "เปิดใช้งาน"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/th.po
+++ b/connector/i18n/th.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:25+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:55+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Thai (http://www.transifex.com/oca/OCA-connector-8-0/language/th/)\n"
 "MIME-Version: 1.0\n"
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr ""
+msgstr "ช่องทาง"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "ช่อง"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "สร้างโดย"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "สร้างเมื่อ"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "วันที่ข้อความล่าสุดโพสต์ในระเบียน"
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "รายละเอียด"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr ""
+msgstr "ชื่อที่ใช้แสดง"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr ""
+msgstr "ผู้ติดตาม"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "จัดกลุ่มโดย"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "รหัส"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr ""
+msgstr "ถ้าเลือก ข้อความใหม่จะต้องการความสนใจจากคุณ"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "วันที่ข้อความล่าสุด"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr ""
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "แก้ไขครั้งสุดท้ายเมื่อ"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "อัพเดทครั้งสุดท้ายโดย"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "อัพเดทครั้งสุดท้ายเมื่อ"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr ""
+msgstr "ข้อความ"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr ""
+msgstr "ข้อความและประวัติการติดต่อ"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "ชื่อ"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr ""
+msgstr "ข้อความที่ยังไม่ได้อ่าน"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "หรือ"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/th.po
+++ b/connector/i18n/th.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:55+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:44+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Thai (http://www.transifex.com/oca/OCA-connector-8-0/language/th/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "บริษัท"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "สถานะ"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/tr.po
+++ b/connector/i18n/tr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-04 09:43+0000\n"
+"PO-Revision-Date: 2016-11-25 14:57+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Turkish (http://www.transifex.com/oca/OCA-connector-8-0/language/tr/)\n"
 "MIME-Version: 1.0\n"
@@ -241,7 +241,7 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "Kayıda eklenen son mesajın tarihi."
 
 #. module: connector
 #: field:queue.job,name:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr ""
+msgstr "Takipçiler"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -325,7 +325,7 @@ msgstr "Grupla"
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 msgid "Group By..."
-msgstr ""
+msgstr "Grupla..."
 
 #. module: connector
 #: help:connector.checkpoint,message_summary:0
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr ""
+msgstr "Eğer işaretlenirse yeni mesajlar dikkatinizi ister."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "Son mesaj tarihi"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -472,7 +472,7 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr ""
+msgstr "Mesajlar"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
@@ -483,13 +483,13 @@ msgstr ""
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr ""
+msgstr "Alan"
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Adı"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -668,7 +668,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
 msgid "State"
-msgstr ""
+msgstr "Durum"
 
 #. module: connector
 #: field:connector.checkpoint,state:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr ""
+msgstr "Okunmamış mesajlar"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "ya da"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/tr.po
+++ b/connector/i18n/tr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"POT-Creation-Date: 2016-12-22 14:19+0000\n"
+"PO-Revision-Date: 2016-12-23 08:32+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Turkish (http://www.transifex.com/oca/OCA-connector-8-0/language/tr/)\n"
 "MIME-Version: 1.0\n"
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Görev"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/tr.po
+++ b/connector/i18n/tr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-22 14:19+0000\n"
-"PO-Revision-Date: 2016-12-23 08:32+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-30 20:32+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Turkish (http://www.transifex.com/oca/OCA-connector-8-0/language/tr/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Aktif"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "Şirket"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -258,7 +258,7 @@ msgstr "Açıklama"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr ""
+msgstr "Görünen İsim"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -298,7 +298,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Failed"
-msgstr ""
+msgstr "Başarısız"
 
 #. module: connector
 #: field:connector.checkpoint,message_follower_ids:0
@@ -333,7 +333,7 @@ msgstr "Grupla..."
 msgid ""
 "Holds the Chatter summary (number of messages, ...). This summary is "
 "directly in html format in order to be inserted in kanban views."
-msgstr ""
+msgstr "Sohbet özetini tutar (kaç mesa vs) Bu özet kanban görünümleri gibi yerlerde kullanılmak için doğrudan HTML formatındadır. "
 
 #. module: connector
 #: field:connector.backend,id:0 field:connector.checkpoint,id:0
@@ -430,7 +430,7 @@ msgstr "Son mesaj tarihi"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "Son değişiklik"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -477,7 +477,7 @@ msgstr "Mesajlar"
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr ""
+msgstr "Mesaj ve iletişim geçmişi"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search

--- a/connector/i18n/tr.po
+++ b/connector/i18n/tr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-30 20:32+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:39+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Turkish (http://www.transifex.com/oca/OCA-connector-8-0/language/tr/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -673,7 +673,7 @@ msgstr "Durum"
 #. module: connector
 #: field:connector.checkpoint,state:0
 msgid "Status"
-msgstr ""
+msgstr "Durum"
 
 #. module: connector
 #: field:connector.checkpoint,message_summary:0

--- a/connector/i18n/tr.po
+++ b/connector/i18n/tr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:39+0000\n"
+"POT-Creation-Date: 2017-05-01 16:08+0000\n"
+"PO-Revision-Date: 2017-06-21 12:52+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Turkish (http://www.transifex.com/oca/OCA-connector-8-0/language/tr/)\n"
 "MIME-Version: 1.0\n"
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr ""
+msgstr "Kanal"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0

--- a/connector/i18n/tr_TR.po
+++ b/connector/i18n/tr_TR.po
@@ -1,0 +1,788 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: connector (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-12-31 02:12+0000\n"
+"PO-Revision-Date: 2017-01-04 14:44+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
+"Language-Team: Turkish (Turkey) (http://www.transifex.com/oca/OCA-connector-8-0/language/tr_TR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: tr_TR\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: connector
+#: model:ir.actions.act_window,help:connector.action_connector_checkpoint
+msgid ""
+"<p>No record to check.</p>\n"
+"                <p> When a connector imports new records which have\n"
+"                    configuration or reviews to do manually, they\n"
+"                    will appear in this list.  Once a record has been\n"
+"                    checked, click on the 'Reviewed' button.  </p>\n"
+"                <p>The connectors list the new records to verify\n"
+"                    based on their type.  Only some need a manual\n"
+"                    review.</p>\n"
+"            "
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/checkpoint/checkpoint.py:136
+#, python-format
+msgid "A %s needs a review."
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,module_portal:0
+msgid "Activate the customer portal"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,active:0
+msgid "Active"
+msgstr "Etkin"
+
+#. module: connector
+#: field:connector.config.settings,alias_domain:0
+msgid "Alias Domain"
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,module_share:0
+msgid "Allow documents sharing"
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,module_google_calendar:0
+msgid "Allow the users to synchronize their calendar  with Google Calendar"
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,module_base_import:0
+msgid "Allow users to import data from CSV files"
+msgstr ""
+
+#. module: connector
+#: view:connector.config.settings:connector.view_connector_config_settings
+msgid "Apply"
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,module_google_drive:0
+msgid "Attach Google documents to any record"
+msgstr ""
+
+#. module: connector
+#: view:connector.config.settings:connector.view_connector_config_settings
+msgid "Backends"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint.review:connector.view_connector_checkpoint_review
+#: view:connector.config.settings:connector.view_connector_config_settings
+#: view:queue.requeue.job:connector.view_requeue_job
+msgid "Cancel"
+msgstr "İptal et"
+
+#. module: connector
+#: code:addons/connector/queue/job.py:619
+#, python-format
+msgid "Canceled. Nothing to do."
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/queue/model.py:457
+#, python-format
+msgid "Cannot change the root channel"
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/queue/model.py:464
+#, python-format
+msgid "Cannot remove the root channel"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search field:queue.job,channel:0
+#: view:queue.job.function:connector.view_queue_job_function_search
+#: field:queue.job.function,channel_id:0
+msgid "Channel"
+msgstr ""
+
+#. module: connector
+#: sql_constraint:queue.job.channel:0
+msgid "Channel complete name must be unique"
+msgstr ""
+
+#. module: connector
+#: model:ir.actions.act_window,name:connector.action_queue_job_channel
+#: model:ir.ui.menu,name:connector.menu_queue_job_channel
+#: view:queue.job.channel:connector.view_queue_job_channel_form
+#: view:queue.job.channel:connector.view_queue_job_channel_search
+#: view:queue.job.channel:connector.view_queue_job_channel_tree
+msgid "Channels"
+msgstr ""
+
+#. module: connector
+#: model:ir.ui.menu,name:connector.menu_checkpoint
+msgid "Checkpoint"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint.review,checkpoint_ids:0
+msgid "Checkpoints"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_connector_checkpoint_review
+msgid "Checkpoints Review"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint:connector.view_connector_checkpoint_form
+msgid "Click on the"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,company_id:0
+msgid "Company"
+msgstr "Firma"
+
+#. module: connector
+#: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
+msgid "Complete Name"
+msgstr ""
+
+#. module: connector
+#: view:connector.config.settings:connector.view_connector_config_settings
+#: model:ir.actions.act_window,name:connector.action_connector_config_settings
+msgid "Configure Connector"
+msgstr ""
+
+#. module: connector
+#: model:ir.module.category,name:connector.module_category_connector
+#: model:ir.ui.menu,name:connector.menu_connector_config_settings
+msgid "Connector"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_connector_backend
+msgid "Connector Backend"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint:connector.view_connector_checkpoint_form
+#: view:connector.checkpoint:connector.view_connector_checkpoint_search
+#: view:connector.checkpoint:connector.view_connector_checkpoint_tree
+#: model:ir.actions.act_window,name:connector.action_connector_checkpoint
+#: model:ir.model,name:connector.model_connector_checkpoint
+msgid "Connector Checkpoint"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_connector_config_settings
+msgid "Connector Configuration"
+msgstr ""
+
+#. module: connector
+#: model:res.groups,name:connector.group_connector_manager
+msgid "Connector Manager"
+msgstr ""
+
+#. module: connector
+#: model:ir.ui.menu,name:connector.menu_connector
+#: model:ir.ui.menu,name:connector.menu_connector_root
+#: view:res.partner:connector.view_partner_connector_form
+msgid "Connectors"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,date_created:0
+msgid "Created Date"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,create_uid:0
+#: field:connector.checkpoint.review,create_uid:0
+#: field:connector.config.settings,create_uid:0
+#: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
+msgid "Created by"
+msgstr "Oluşturan"
+
+#. module: connector
+#: field:connector.checkpoint,create_date:0
+#: field:connector.checkpoint.review,create_date:0
+#: field:connector.config.settings,create_date:0
+#: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
+msgid "Created on"
+msgstr "Oluşturulma tarihi"
+
+#. module: connector
+#: field:queue.job,retry:0
+msgid "Current try"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_form
+msgid "Current try / max. retries"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,date_done:0
+msgid "Date Done"
+msgstr ""
+
+#. module: connector
+#: help:connector.checkpoint,message_last_post:0
+#: help:queue.job,message_last_post:0
+msgid "Date of the last message posted on the record."
+msgstr ""
+
+#. module: connector
+#: field:queue.job,name:0
+msgid "Description"
+msgstr "Açıklama"
+
+#. module: connector
+#: field:connector.backend,display_name:0
+#: field:connector.checkpoint,display_name:0
+#: field:connector.checkpoint.review,display_name:0
+#: field:connector.config.settings,display_name:0
+#: field:external.binding,display_name:0 field:queue.job,display_name:0
+#: field:queue.job.channel,display_name:0
+#: field:queue.job.function,display_name:0
+#: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
+msgid "Display Name"
+msgstr "Görünen ad"
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
+msgid "Done"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,date_enqueued:0
+msgid "Enqueue Time"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
+msgid "Enqueued"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,exc_info:0
+msgid "Exception Info"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_form
+msgid "Exception Information"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,eta:0
+msgid "Execute only after"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_external_binding
+msgid "External Binding (abstract)"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
+msgid "Failed"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,message_follower_ids:0
+#: field:queue.job,message_follower_ids:0
+msgid "Followers"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,func_name:0
+msgid "Func name"
+msgstr ""
+
+#. module: connector
+#: help:connector.config.settings,module_portal:0
+msgid "Give your customers access to their documents."
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search
+#: view:queue.job.function:connector.view_queue_job_function_search
+msgid "Group By"
+msgstr "Grupla"
+
+#. module: connector
+#: view:connector.checkpoint:connector.view_connector_checkpoint_search
+msgid "Group By..."
+msgstr ""
+
+#. module: connector
+#: help:connector.checkpoint,message_summary:0
+#: help:queue.job,message_summary:0
+msgid ""
+"Holds the Chatter summary (number of messages, ...). This summary is "
+"directly in html format in order to be inserted in kanban views."
+msgstr ""
+
+#. module: connector
+#: field:connector.backend,id:0 field:connector.checkpoint,id:0
+#: field:connector.checkpoint.review,id:0 field:connector.config.settings,id:0
+#: field:external.binding,id:0 field:queue.job,id:0
+#: field:queue.job.channel,id:0 field:queue.job.function,id:0
+#: field:queue.requeue.job,id:0 field:queue.worker,id:0
+msgid "ID"
+msgstr "Kimlik"
+
+#. module: connector
+#: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
+msgid "If checked new messages require your attention."
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_form
+msgid "If the max. retries is 0, the number of retries is infinite."
+msgstr ""
+
+#. module: connector
+#: help:connector.config.settings,alias_domain:0
+msgid ""
+"If you have setup a catch-all email domain redirected to the Odoo server, "
+"enter the domain name here."
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,backend_id:0
+msgid "Imported from"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,message_is_follower:0
+#: field:queue.job,message_is_follower:0
+msgid "Is a Follower"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_queue_job_channel
+msgid "Job Channels"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search
+#: field:queue.job,job_function_id:0
+msgid "Job Function"
+msgstr ""
+
+#. module: connector
+#: model:ir.actions.act_window,name:connector.action_queue_job_function
+#: model:ir.model,name:connector.model_queue_job_function
+#: model:ir.ui.menu,name:connector.menu_queue_job_function
+#: field:queue.job.channel,job_function_ids:0
+#: view:queue.job.function:connector.view_queue_job_function_form
+#: view:queue.job.function:connector.view_queue_job_function_search
+#: view:queue.job.function:connector.view_queue_job_function_tree
+msgid "Job Functions"
+msgstr ""
+
+#. module: connector
+#: model:mail.message.subtype,name:connector.mt_job_failed
+msgid "Job failed"
+msgstr ""
+
+#. module: connector
+#: model:ir.actions.act_window,name:connector.action_queue_job
+#: model:ir.ui.menu,name:connector.menu_queue_job
+#: view:queue.job:connector.view_queue_job_form
+#: view:queue.job:connector.view_queue_job_search
+#: view:queue.job:connector.view_queue_job_tree
+#: field:queue.requeue.job,job_ids:0 field:queue.worker,job_ids:0
+msgid "Jobs"
+msgstr ""
+
+#. module: connector
+#: field:queue.worker,date_alive:0
+msgid "Last Alive Check"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,message_last_post:0
+#: field:queue.job,message_last_post:0
+msgid "Last Message Date"
+msgstr ""
+
+#. module: connector
+#: field:connector.backend,__last_update:0
+#: field:connector.checkpoint,__last_update:0
+#: field:connector.checkpoint.review,__last_update:0
+#: field:connector.config.settings,__last_update:0
+#: field:external.binding,__last_update:0 field:queue.job,__last_update:0
+#: field:queue.job.channel,__last_update:0
+#: field:queue.job.function,__last_update:0
+#: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
+msgid "Last Modified on"
+msgstr "En son güncelleme tarihi"
+
+#. module: connector
+#: field:connector.checkpoint,write_uid:0
+#: field:connector.checkpoint.review,write_uid:0
+#: field:connector.config.settings,write_uid:0
+#: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
+msgid "Last Updated by"
+msgstr "En son güncelleyen "
+
+#. module: connector
+#: field:connector.checkpoint,write_date:0
+#: field:connector.checkpoint.review,write_date:0
+#: field:connector.config.settings,write_date:0
+#: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
+msgid "Last Updated on"
+msgstr "En son güncelleme tarihi"
+
+#. module: connector
+#: field:external.binding,sync_date:0
+msgid "Last synchronization date"
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,module_multi_company:0
+msgid "Manage multiple companies"
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/queue/model.py:141
+#, python-format
+msgid "Manually set to done by %s"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,max_retries:0
+msgid "Max. retries"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
+msgid "Messages"
+msgstr ""
+
+#. module: connector
+#: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
+msgid "Messages and communication history"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint:connector.view_connector_checkpoint_search
+#: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
+msgid "Model"
+msgstr "Tip"
+
+#. module: connector
+#: field:connector.backend,name:0 field:queue.job.channel,name:0
+#: field:queue.job.function,name:0
+msgid "Name"
+msgstr "Ad"
+
+#. module: connector
+#: help:connector.checkpoint,name:0
+msgid "Name of the record to review"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint:connector.view_connector_checkpoint_search
+#: selection:connector.checkpoint,state:0
+msgid "Need Review"
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/queue/model.py:117
+#, python-format
+msgid "No action available for this job"
+msgstr ""
+
+#. module: connector
+#: model:ir.actions.client,name:connector.action_client_connector_menu
+msgid "Open Connector Menu"
+msgstr ""
+
+#. module: connector
+#: field:queue.worker,pid:0
+msgid "PID"
+msgstr ""
+
+#. module: connector
+#: field:queue.job.channel,parent_id:0
+msgid "Parent Channel"
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/queue/model.py:449
+#, python-format
+msgid "Parent channel required."
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
+msgid "Pending"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,func:0
+msgid "Pickled Function"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,priority:0
+msgid "Priority"
+msgstr ""
+
+#. module: connector
+#: model:ir.ui.menu,name:connector.menu_queue
+msgid "Queue"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_queue_job
+msgid "Queue Job"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_queue_worker
+msgid "Queue Worker"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,record:0
+msgid "Record"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,record_id:0
+msgid "Record ID"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,name:0
+msgid "Record Name"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_form
+msgid "Related"
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/related_action.py:48
+#, python-format
+msgid "Related Record"
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,font:0
+msgid "Report Font"
+msgstr ""
+
+#. module: connector
+#: view:queue.requeue.job:connector.view_requeue_job
+msgid "Requeue"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_form
+msgid "Requeue Job"
+msgstr ""
+
+#. module: connector
+#: model:ir.actions.act_window,name:connector.action_requeue_job
+#: view:queue.requeue.job:connector.view_requeue_job
+msgid "Requeue Jobs"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_form field:queue.job,result:0
+msgid "Result"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint.review:connector.view_connector_checkpoint_review
+#: model:ir.actions.act_window,name:connector.action_connector_checkpoint_review
+msgid "Review Checkpoints"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint:connector.view_connector_checkpoint_form
+#: view:connector.checkpoint:connector.view_connector_checkpoint_search
+#: view:connector.checkpoint:connector.view_connector_checkpoint_tree
+#: selection:connector.checkpoint,state:0
+msgid "Reviewed"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint.review:connector.view_connector_checkpoint_review
+msgid "Set as reviewed"
+msgstr ""
+
+#. module: connector
+#: help:connector.config.settings,font:0
+msgid ""
+"Set the font into the report header, it will be used as default font in the "
+"RML reports of the user company"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_form
+msgid "Set to 'Done'"
+msgstr ""
+
+#. module: connector
+#: help:connector.config.settings,module_share:0
+msgid "Share or embbed any screen of Odoo."
+msgstr ""
+
+#. module: connector
+#: code:addons/connector/queue/model.py:187
+#, python-format
+msgid ""
+"Something bad happened during the execution of the job. More details in the "
+"'Exception Information' section."
+msgstr ""
+
+#. module: connector
+#: field:queue.job,date_started:0 field:queue.worker,date_start:0
+msgid "Start Date"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
+msgid "Started"
+msgstr ""
+
+#. module: connector
+#: view:queue.job:connector.view_queue_job_search field:queue.job,state:0
+msgid "State"
+msgstr "Hal"
+
+#. module: connector
+#: field:connector.checkpoint,state:0
+msgid "Status"
+msgstr "Durum"
+
+#. module: connector
+#: field:connector.checkpoint,message_summary:0
+#: field:queue.job,message_summary:0
+msgid "Summary"
+msgstr ""
+
+#. module: connector
+#: field:queue.job,func_string:0
+msgid "Task"
+msgstr ""
+
+#. module: connector
+#: help:queue.job,max_retries:0
+msgid ""
+"The job will fail if the number of tries reach the max. retries.\n"
+"Retries are infinite when empty."
+msgstr ""
+
+#. module: connector
+#: help:connector.checkpoint,backend_id:0
+msgid "The record has been imported from this backend"
+msgstr ""
+
+#. module: connector
+#: help:connector.checkpoint,record:0
+msgid "The record to review."
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint.review:connector.view_connector_checkpoint_review
+msgid "The selected checkpoints will be set as reviewed."
+msgstr ""
+
+#. module: connector
+#: view:queue.requeue.job:connector.view_requeue_job
+msgid "The selected jobs will be requeued."
+msgstr ""
+
+#. module: connector
+#: help:connector.config.settings,module_google_calendar:0
+msgid "This installs the module google_calendar."
+msgstr ""
+
+#. module: connector
+#: help:connector.config.settings,module_google_drive:0
+msgid "This installs the module google_docs."
+msgstr ""
+
+#. module: connector
+#: field:queue.job,uuid:0 field:queue.worker,uuid:0
+msgid "UUID"
+msgstr ""
+
+#. module: connector
+#: field:connector.checkpoint,message_unread:0
+#: field:queue.job,message_unread:0
+msgid "Unread Messages"
+msgstr ""
+
+#. module: connector
+#: field:connector.config.settings,module_auth_oauth:0
+msgid ""
+"Use external authentication providers, sign in with google, facebook, ..."
+msgstr ""
+
+#. module: connector
+#: field:queue.job,user_id:0
+msgid "User ID"
+msgstr ""
+
+#. module: connector
+#: field:connector.backend,version:0
+msgid "Version"
+msgstr ""
+
+#. module: connector
+#: model:ir.model,name:connector.model_queue_requeue_job
+msgid "Wizard to requeue a selection of jobs"
+msgstr ""
+
+#. module: connector
+#: help:connector.config.settings,module_multi_company:0
+msgid ""
+"Work in multi-company environments, with appropriate security access between companies.\n"
+"-This installs the module multi_company."
+msgstr ""
+
+#. module: connector
+#: field:queue.job,worker_id:0
+#: view:queue.worker:connector.view_queue_worker_form
+#: view:queue.worker:connector.view_queue_worker_tree
+msgid "Worker"
+msgstr ""
+
+#. module: connector
+#: model:ir.actions.act_window,name:connector.action_queue_worker
+#: model:ir.ui.menu,name:connector.menu_queue_worker
+msgid "Workers"
+msgstr ""
+
+#. module: connector
+#: view:connector.checkpoint.review:connector.view_connector_checkpoint_review
+#: view:connector.config.settings:connector.view_connector_config_settings
+#: view:queue.requeue.job:connector.view_requeue_job
+msgid "or"
+msgstr "ya da "
+
+#. module: connector
+#: view:connector.checkpoint:connector.view_connector_checkpoint_form
+msgid "to verify it:"
+msgstr ""

--- a/connector/i18n/uk.po
+++ b/connector/i18n/uk.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-10-11 09:51+0000\n"
+"POT-Creation-Date: 2016-12-24 00:45+0000\n"
+"PO-Revision-Date: 2016-12-27 08:26+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Ukrainian (http://www.transifex.com/oca/OCA-connector-8-0/language/uk/)\n"
 "MIME-Version: 1.0\n"
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr ""
+msgstr "Скасувати"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619

--- a/connector/i18n/uk.po
+++ b/connector/i18n/uk.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-27 08:26+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-27 13:40+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Ukrainian (http://www.transifex.com/oca/OCA-connector-8-0/language/uk/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "
@@ -684,7 +684,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,func_string:0
 msgid "Task"
-msgstr ""
+msgstr "Завдання"
 
 #. module: connector
 #: help:queue.job,max_retries:0

--- a/connector/i18n/uk.po
+++ b/connector/i18n/uk.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-10-11 09:51+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Ukrainian (http://www.transifex.com/oca/OCA-connector-8-0/language/uk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: uk\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr ""
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Канали"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "Створив"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "Дата створення"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "Дата останнього повідомлення по запису."
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "Опис"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "Назва для відображення"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "Підписники"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "Групувати за"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -347,7 +347,7 @@ msgstr "ID"
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "Якщо позначено, то повідомленя потребує вашої уваги"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "Дата останнього повідомлення"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "Остання модифікація"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "Востаннє оновив"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "Останнє оновлення"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "Повідомлення"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "Повідомлення та історія бесіди"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "Name"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -577,7 +577,7 @@ msgstr ""
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
 msgid "Related"
-msgstr ""
+msgstr "Пов’язано"
 
 #. module: connector
 #: code:addons/connector/related_action.py:48
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "Непрочитані повідомлення"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "або"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/vi.po
+++ b/connector/i18n/vi.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-08 05:51+0000\n"
-"PO-Revision-Date: 2016-09-09 12:24+0000\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:55+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Vietnamese (http://www.transifex.com/oca/OCA-connector-8-0/language/vi/)\n"
 "MIME-Version: 1.0\n"
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr ""
+msgstr "Kênh"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "Kênh"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr ""
+msgstr "Được tạo bởi"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr ""
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr ""
+msgstr "Được tạo vào"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "Ngày của thông điệp gần nhất được ghi nhận trên một bản ghi"
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr ""
+msgstr "Miêu tả"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr ""
+msgstr "Tên hiển thị"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr ""
+msgstr "Người dõi theo"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr ""
+msgstr "Group By"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr ""
+msgstr "Nếu đánh dấu kiểm, các thông điệp mới yêu cầu sự có mặt của bạn."
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr ""
+msgstr "Ngày thông điệp cuối cùng"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr ""
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr ""
+msgstr "Sửa lần cuối vào"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr ""
+msgstr "Last Updated by"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr ""
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr ""
+msgstr "Cập nhật lần cuối vào"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr ""
+msgstr "Thông điệp"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr ""
+msgstr "Lịch sử trao đổi"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Tên"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr ""
+msgstr "Thông điệp chưa đọc"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr ""
+msgstr "hoặc"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/i18n/vi.po
+++ b/connector/i18n/vi.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:55+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:26+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Vietnamese (http://www.transifex.com/oca/OCA-connector-8-0/language/vi/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "Hoạt động"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/vi_VN.po
+++ b/connector/i18n/vi_VN.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-27 08:24+0000\n"
+"POT-Creation-Date: 2017-07-01 01:36+0000\n"
+"PO-Revision-Date: 2017-08-11 11:56+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Vietnamese (Viet Nam) (http://www.transifex.com/oca/OCA-connector-8-0/language/vi_VN/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr ""
+msgstr "Tên"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/vi_VN.po
+++ b/connector/i18n/vi_VN.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-24 00:45+0000\n"
-"PO-Revision-Date: 2016-12-21 19:23+0000\n"
+"PO-Revision-Date: 2016-12-27 08:24+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: French (Canada) (http://www.transifex.com/oca/OCA-connector-8-0/language/fr_CA/)\n"
+"Language-Team: Vietnamese (Viet Nam) (http://www.transifex.com/oca/OCA-connector-8-0/language/vi_VN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: fr_CA\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: vi_VN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Annuler"
+msgstr "Hủy"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -212,7 +212,7 @@ msgstr ""
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Créé par"
+msgstr "Tạo bởi"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Créé par"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Créé le"
+msgstr "Tạo vào"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -258,7 +258,7 @@ msgstr ""
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Afficher le nom"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -342,7 +342,7 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr "Identifiant"
+msgstr "ID"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
@@ -438,7 +438,7 @@ msgstr ""
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Dernière mise à jour par"
+msgstr "Cập nhật lần cuối bởi"
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Dernière mise à jour par"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Dernière mise à jour le"
+msgstr "Cập nhật lần cuối vào"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -483,13 +483,13 @@ msgstr ""
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
 #: field:connector.checkpoint,model_id:0 field:queue.job,model_name:0
 msgid "Model"
-msgstr "Modèle"
+msgstr ""
 
 #. module: connector
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Nom"
+msgstr ""
 
 #. module: connector
 #: help:connector.checkpoint,name:0

--- a/connector/i18n/zh_CN.po
+++ b/connector/i18n/zh_CN.po
@@ -4,14 +4,14 @@
 # 
 # Translators:
 # zeng <z_fy@live.cn>, 2016
-# zeng <z_fy@live.cn>, 2016
+# zeng <z_fy@live.cn>, 2016-2017
 msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:56+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
+"POT-Creation-Date: 2017-01-21 01:31+0000\n"
+"PO-Revision-Date: 2017-02-01 15:02+0000\n"
+"Last-Translator: zeng <z_fy@live.cn>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/oca/OCA-connector-8-0/language/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -95,7 +95,7 @@ msgstr "取消"
 #: code:addons/connector/queue/job.py:619
 #, python-format
 msgid "Canceled. Nothing to do."
-msgstr ""
+msgstr "已取消"
 
 #. module: connector
 #: code:addons/connector/queue/model.py:457
@@ -311,7 +311,7 @@ msgstr "听众"
 #. module: connector
 #: field:queue.job,func_name:0
 msgid "Func name"
-msgstr ""
+msgstr "函数名称"
 
 #. module: connector
 #: help:connector.config.settings,module_portal:0

--- a/connector/i18n/zh_CN.po
+++ b/connector/i18n/zh_CN.po
@@ -3,15 +3,16 @@
 # * connector
 # 
 # Translators:
+# liAnGjiA <liangjia@qq.com>, 2017
 # zeng <z_fy@live.cn>, 2016
 # zeng <z_fy@live.cn>, 2016-2017
 msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-19 01:22+0000\n"
-"Last-Translator: zeng <z_fy@live.cn>\n"
+"POT-Creation-Date: 2017-08-12 01:33+0000\n"
+"PO-Revision-Date: 2017-08-18 06:48+0000\n"
+"Last-Translator: liAnGjiA <liangjia@qq.com>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/oca/OCA-connector-8-0/language/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -559,12 +560,12 @@ msgstr "队列中作业"
 #. module: connector
 #: model:ir.model,name:connector.model_queue_worker
 msgid "Queue Worker"
-msgstr ""
+msgstr "作业队列"
 
 #. module: connector
 #: field:connector.checkpoint,record:0
 msgid "Record"
-msgstr ""
+msgstr "记录"
 
 #. module: connector
 #: field:connector.checkpoint,record_id:0
@@ -574,7 +575,7 @@ msgstr "记录 ID"
 #. module: connector
 #: field:connector.checkpoint,name:0
 msgid "Record Name"
-msgstr ""
+msgstr "记录名"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form

--- a/connector/i18n/zh_CN.po
+++ b/connector/i18n/zh_CN.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-16 08:00+0000\n"
-"PO-Revision-Date: 2016-04-16 14:15+0000\n"
-"Last-Translator: zeng <z_fy@live.cn>\n"
+"POT-Creation-Date: 2016-09-17 07:17+0000\n"
+"PO-Revision-Date: 2016-11-25 14:56+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/oca/OCA-connector-8-0/language/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -243,12 +243,24 @@ msgstr "完成日期"
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr ""
+msgstr "发布到记录上的最后消息的日期"
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
 msgstr "描述"
+
+#. module: connector
+#: field:connector.backend,display_name:0
+#: field:connector.checkpoint,display_name:0
+#: field:connector.checkpoint.review,display_name:0
+#: field:connector.config.settings,display_name:0
+#: field:external.binding,display_name:0 field:queue.job,display_name:0
+#: field:queue.job.channel,display_name:0
+#: field:queue.job.function,display_name:0
+#: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
+msgid "Display Name"
+msgstr "显示名称"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
@@ -411,6 +423,18 @@ msgid "Last Message Date"
 msgstr "最近消息日期"
 
 #. module: connector
+#: field:connector.backend,__last_update:0
+#: field:connector.checkpoint,__last_update:0
+#: field:connector.checkpoint.review,__last_update:0
+#: field:connector.config.settings,__last_update:0
+#: field:external.binding,__last_update:0 field:queue.job,__last_update:0
+#: field:queue.job.channel,__last_update:0
+#: field:queue.job.function,__last_update:0
+#: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
+msgid "Last Modified on"
+msgstr "最后修改时间"
+
+#. module: connector
 #: field:connector.checkpoint,write_uid:0
 #: field:connector.checkpoint.review,write_uid:0
 #: field:connector.config.settings,write_uid:0
@@ -468,6 +492,11 @@ msgstr "模型"
 #: field:queue.job.function,name:0
 msgid "Name"
 msgstr "名称"
+
+#. module: connector
+#: help:connector.checkpoint,name:0
+msgid "Name of the record to review"
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -533,9 +562,19 @@ msgid "Queue Worker"
 msgstr ""
 
 #. module: connector
+#: field:connector.checkpoint,record:0
+msgid "Record"
+msgstr ""
+
+#. module: connector
 #: field:connector.checkpoint,record_id:0
 msgid "Record ID"
 msgstr "记录 ID"
+
+#. module: connector
+#: field:connector.checkpoint,name:0
+msgid "Record Name"
+msgstr ""
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -660,6 +699,11 @@ msgstr "如果尝试次数达到最大重试数，作业将被标记为失败\n�
 #: help:connector.checkpoint,backend_id:0
 msgid "The record has been imported from this backend"
 msgstr "记录已经成功从后台导入"
+
+#. module: connector
+#: help:connector.checkpoint,record:0
+msgid "The record to review."
+msgstr ""
 
 #. module: connector
 #: view:connector.checkpoint.review:connector.view_connector_checkpoint_review

--- a/connector/i18n/zh_CN.po
+++ b/connector/i18n/zh_CN.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-21 01:31+0000\n"
-"PO-Revision-Date: 2017-02-01 15:02+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-19 01:22+0000\n"
 "Last-Translator: zeng <z_fy@live.cn>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/oca/OCA-connector-8-0/language/zh_CN/)\n"
 "MIME-Version: 1.0\n"
@@ -98,13 +98,13 @@ msgid "Canceled. Nothing to do."
 msgstr "已取消"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr "不能修改根节点"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr "不能移除根节点"
@@ -526,7 +526,7 @@ msgid "Parent Channel"
 msgstr "上级节点"
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr "需要指定上级节点"
@@ -650,7 +650,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/zh_TW.po
+++ b/connector/i18n/zh_TW.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-22 16:24+0000\n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-25 10:42+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/oca/OCA-connector-8-0/language/zh_TW/)\n"
 "MIME-Version: 1.0\n"
@@ -96,13 +96,13 @@ msgid "Canceled. Nothing to do."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:457
+#: code:addons/connector/queue/model.py:462
 #, python-format
 msgid "Cannot change the root channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:464
+#: code:addons/connector/queue/model.py:469
 #, python-format
 msgid "Cannot remove the root channel"
 msgstr ""
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr ""
+msgstr "公司"
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -524,7 +524,7 @@ msgid "Parent Channel"
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:449
+#: code:addons/connector/queue/model.py:454
 #, python-format
 msgid "Parent channel required."
 msgstr ""
@@ -648,7 +648,7 @@ msgid "Share or embbed any screen of Odoo."
 msgstr ""
 
 #. module: connector
-#: code:addons/connector/queue/model.py:187
+#: code:addons/connector/queue/model.py:192
 #, python-format
 msgid ""
 "Something bad happened during the execution of the job. More details in the "

--- a/connector/i18n/zh_TW.po
+++ b/connector/i18n/zh_TW.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-25 10:42+0000\n"
+"POT-Creation-Date: 2017-08-22 13:04+0000\n"
+"PO-Revision-Date: 2017-08-21 07:22+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/oca/OCA-connector-8-0/language/zh_TW/)\n"
 "MIME-Version: 1.0\n"
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr ""
+msgstr "活躍"
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0

--- a/connector/i18n/zh_TW.po
+++ b/connector/i18n/zh_TW.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: connector (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-09-17 07:17+0000\n"
-"PO-Revision-Date: 2016-11-25 14:57+0000\n"
+"PO-Revision-Date: 2016-11-22 16:24+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Bulgarian (http://www.transifex.com/oca/OCA-connector-8-0/language/bg/)\n"
+"Language-Team: Chinese (Taiwan) (http://www.transifex.com/oca/OCA-connector-8-0/language/zh_TW/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: zh_TW\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #. module: connector
 #: model:ir.actions.act_window,help:connector.action_connector_checkpoint
@@ -45,7 +45,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,active:0
 msgid "Active"
-msgstr "Активен"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,alias_domain:0
@@ -70,7 +70,7 @@ msgstr ""
 #. module: connector
 #: view:connector.config.settings:connector.view_connector_config_settings
 msgid "Apply"
-msgstr "Приложи"
+msgstr ""
 
 #. module: connector
 #: field:connector.config.settings,module_google_drive:0
@@ -87,7 +87,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "Cancel"
-msgstr "Откажи"
+msgstr "刪除"
 
 #. module: connector
 #: code:addons/connector/queue/job.py:619
@@ -112,7 +112,7 @@ msgstr ""
 #: view:queue.job.function:connector.view_queue_job_function_search
 #: field:queue.job.function,channel_id:0
 msgid "Channel"
-msgstr "Канал"
+msgstr "管道"
 
 #. module: connector
 #: sql_constraint:queue.job.channel:0
@@ -126,7 +126,7 @@ msgstr ""
 #: view:queue.job.channel:connector.view_queue_job_channel_search
 #: view:queue.job.channel:connector.view_queue_job_channel_tree
 msgid "Channels"
-msgstr ""
+msgstr "管道"
 
 #. module: connector
 #: model:ir.ui.menu,name:connector.menu_checkpoint
@@ -151,7 +151,7 @@ msgstr ""
 #. module: connector
 #: field:queue.job,company_id:0
 msgid "Company"
-msgstr "Фирма"
+msgstr ""
 
 #. module: connector
 #: field:queue.job.channel,complete_name:0 field:queue.job.function,channel:0
@@ -168,7 +168,7 @@ msgstr ""
 #: model:ir.module.category,name:connector.module_category_connector
 #: model:ir.ui.menu,name:connector.menu_connector_config_settings
 msgid "Connector"
-msgstr "Конектор"
+msgstr ""
 
 #. module: connector
 #: model:ir.model,name:connector.model_connector_backend
@@ -199,12 +199,12 @@ msgstr ""
 #: model:ir.ui.menu,name:connector.menu_connector_root
 #: view:res.partner:connector.view_partner_connector_form
 msgid "Connectors"
-msgstr "Конектори"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_created:0
 msgid "Created Date"
-msgstr "Създаден на"
+msgstr ""
 
 #. module: connector
 #: field:connector.checkpoint,create_uid:0
@@ -212,7 +212,7 @@ msgstr "Създаден на"
 #: field:connector.config.settings,create_uid:0
 #: field:queue.job.channel,create_uid:0 field:queue.requeue.job,create_uid:0
 msgid "Created by"
-msgstr "Създадено от"
+msgstr "建立者"
 
 #. module: connector
 #: field:connector.checkpoint,create_date:0
@@ -220,7 +220,7 @@ msgstr "Създадено от"
 #: field:connector.config.settings,create_date:0
 #: field:queue.job.channel,create_date:0 field:queue.requeue.job,create_date:0
 msgid "Created on"
-msgstr "Създадено на"
+msgstr "建立於"
 
 #. module: connector
 #: field:queue.job,retry:0
@@ -241,12 +241,12 @@ msgstr ""
 #: help:connector.checkpoint,message_last_post:0
 #: help:queue.job,message_last_post:0
 msgid "Date of the last message posted on the record."
-msgstr "Дата на последното съобщение, публикувано на записа."
+msgstr "釋出到記錄上的最後資訊的日期"
 
 #. module: connector
 #: field:queue.job,name:0
 msgid "Description"
-msgstr "Описание"
+msgstr "說明"
 
 #. module: connector
 #: field:connector.backend,display_name:0
@@ -258,12 +258,12 @@ msgstr "Описание"
 #: field:queue.job.function,display_name:0
 #: field:queue.requeue.job,display_name:0 field:queue.worker,display_name:0
 msgid "Display Name"
-msgstr "Име за Показване"
+msgstr "顯示名稱"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_search selection:queue.job,state:0
 msgid "Done"
-msgstr "Готово"
+msgstr ""
 
 #. module: connector
 #: field:queue.job,date_enqueued:0
@@ -304,7 +304,7 @@ msgstr ""
 #: field:connector.checkpoint,message_follower_ids:0
 #: field:queue.job,message_follower_ids:0
 msgid "Followers"
-msgstr "Последователи"
+msgstr "關注者"
 
 #. module: connector
 #: field:queue.job,func_name:0
@@ -320,7 +320,7 @@ msgstr ""
 #: view:queue.job:connector.view_queue_job_search
 #: view:queue.job.function:connector.view_queue_job_function_search
 msgid "Group By"
-msgstr "Групирай По"
+msgstr "分組方式"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -342,12 +342,12 @@ msgstr ""
 #: field:queue.job.channel,id:0 field:queue.job.function,id:0
 #: field:queue.requeue.job,id:0 field:queue.worker,id:0
 msgid "ID"
-msgstr "ID"
+msgstr "編號"
 
 #. module: connector
 #: help:connector.checkpoint,message_unread:0 help:queue.job,message_unread:0
 msgid "If checked new messages require your attention."
-msgstr "Ако е отбелязано, новите съобщения ще изискват внимание."
+msgstr "當有新訊息時通知您。"
 
 #. module: connector
 #: view:queue.job:connector.view_queue_job_form
@@ -418,7 +418,7 @@ msgstr ""
 #: field:connector.checkpoint,message_last_post:0
 #: field:queue.job,message_last_post:0
 msgid "Last Message Date"
-msgstr "Дата на последното съобщение"
+msgstr "最後訊息日期"
 
 #. module: connector
 #: field:connector.backend,__last_update:0
@@ -430,7 +430,7 @@ msgstr "Дата на последното съобщение"
 #: field:queue.job.function,__last_update:0
 #: field:queue.requeue.job,__last_update:0 field:queue.worker,__last_update:0
 msgid "Last Modified on"
-msgstr "Последно обновено на"
+msgstr "最後修改:"
 
 #. module: connector
 #: field:connector.checkpoint,write_uid:0
@@ -438,7 +438,7 @@ msgstr "Последно обновено на"
 #: field:connector.config.settings,write_uid:0
 #: field:queue.job.channel,write_uid:0 field:queue.requeue.job,write_uid:0
 msgid "Last Updated by"
-msgstr "Последно обновено от"
+msgstr "最後更新："
 
 #. module: connector
 #: field:connector.checkpoint,write_date:0
@@ -446,7 +446,7 @@ msgstr "Последно обновено от"
 #: field:connector.config.settings,write_date:0
 #: field:queue.job.channel,write_date:0 field:queue.requeue.job,write_date:0
 msgid "Last Updated on"
-msgstr "Последно обновено на"
+msgstr "最後更新於"
 
 #. module: connector
 #: field:external.binding,sync_date:0
@@ -472,12 +472,12 @@ msgstr ""
 #. module: connector
 #: field:connector.checkpoint,message_ids:0 field:queue.job,message_ids:0
 msgid "Messages"
-msgstr "Съобщения"
+msgstr "訊息"
 
 #. module: connector
 #: help:connector.checkpoint,message_ids:0 help:queue.job,message_ids:0
 msgid "Messages and communication history"
-msgstr "История на събщенията и комуникациите"
+msgstr "訊息及聯絡紀錄"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_search
@@ -489,7 +489,7 @@ msgstr ""
 #: field:connector.backend,name:0 field:queue.job.channel,name:0
 #: field:queue.job.function,name:0
 msgid "Name"
-msgstr "Име"
+msgstr "名稱"
 
 #. module: connector
 #: help:connector.checkpoint,name:0
@@ -732,7 +732,7 @@ msgstr ""
 #: field:connector.checkpoint,message_unread:0
 #: field:queue.job,message_unread:0
 msgid "Unread Messages"
-msgstr "Непрочетени съобщения"
+msgstr "未讀訊息"
 
 #. module: connector
 #: field:connector.config.settings,module_auth_oauth:0
@@ -780,7 +780,7 @@ msgstr ""
 #: view:connector.config.settings:connector.view_connector_config_settings
 #: view:queue.requeue.job:connector.view_requeue_job
 msgid "or"
-msgstr "или"
+msgstr "或"
 
 #. module: connector
 #: view:connector.checkpoint:connector.view_connector_checkpoint_form

--- a/connector/producer.py
+++ b/connector/producer.py
@@ -51,6 +51,8 @@ def create(self, vals):
                                    context=self.env.context)
         on_record_create.fire(session, self._name, record_id.id, vals)
     return record_id
+
+
 models.BaseModel.create = create
 
 
@@ -68,6 +70,8 @@ def write(self, vals):
                 on_record_write.fire(session, self._name,
                                      record_id, vals)
     return result
+
+
 models.BaseModel.write = write
 
 
@@ -83,4 +87,6 @@ def unlink(self):
             for record_id in self.ids:
                 on_record_unlink.fire(session, self._name, record_id)
     return unlink_original(self)
+
+
 models.BaseModel.unlink = unlink

--- a/connector/queue/model.py
+++ b/connector/queue/model.py
@@ -162,8 +162,7 @@ class QueueJob(models.Model):
         return res
 
     @api.multi
-    def _subscribe_users(self):
-        """ Subscribe all users having the 'Connector Manager' group """
+    def _get_subscribe_users_domain(self):
         group = self.env.ref('connector.group_connector_manager')
         if not group:
             return
@@ -171,6 +170,12 @@ class QueueJob(models.Model):
         domain = [('groups_id', '=', group.id)]
         if companies:
             domain.append(('company_id', 'child_of', companies.ids))
+        return domain
+
+    @api.multi
+    def _subscribe_users(self):
+        """ Subscribe all users having the 'Connector Manager' group """
+        domain = self._get_subscribe_users_domain()
         users = self.env['res.users'].search(domain)
         self.message_subscribe_users(user_ids=users.ids)
 

--- a/connector/queue/worker.py
+++ b/connector/queue/worker.py
@@ -345,6 +345,7 @@ def start_service():
     watcher.daemon = True
     watcher.start()
 
+
 # We have to launch the Jobs Workers only if:
 # 0. The alternative connector runner is not enabled (i.e. no ``_channels()``)
 # 1. OpenERP is used in standalone mode (monoprocess)

--- a/connector_job_subscribe/README.rst
+++ b/connector_job_subscribe/README.rst
@@ -1,0 +1,58 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Connector Job Suscription
+===========================
+
+This module was written to extend the connector management. It allows to
+be member of group Connector manager without being follower of all jobs.
+This can avoid for some users to receive a lot of emails in case of failing
+jobs.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/connector/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/connector/issues/new?body
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/102/8.0
+
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Cédric Pigeon <cedric.pigeon@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/connector_job_subscribe/__init__.py
+++ b/connector_job_subscribe/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import models
+from . import queue

--- a/connector_job_subscribe/__openerp__.py
+++ b/connector_job_subscribe/__openerp__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{'name': 'Connector',
+ 'version': '8.0.1.0.0',
+ 'author': 'Acsone SA/Nv,'
+           'Odoo Community Association (OCA)',
+ 'website': 'http://www.acsone.eu',
+ 'license': 'AGPL-3',
+ 'category': 'Generic Modules',
+ 'depends': ['connector'
+             ],
+
+ 'data': [
+     'views/res_users_view.xml',
+ ],
+ 'installable': True,
+ }

--- a/connector_job_subscribe/i18n/ar.po
+++ b/connector_job_subscribe/i18n/ar.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Arabic (https://www.transifex.com/oca/teams/23907/ar/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ar\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "المستخدمون"

--- a/connector_job_subscribe/i18n/bg.po
+++ b/connector_job_subscribe/i18n/bg.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# Kaloyan Naumov <kaloyan@lumnus.net>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: Kaloyan Naumov <kaloyan@lumnus.net>, 2017\n"
+"Language-Team: Bulgarian (https://www.transifex.com/oca/teams/23907/bg/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: bg\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr "Конектори"
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr ""

--- a/connector_job_subscribe/i18n/ca.po
+++ b/connector_job_subscribe/i18n/ca.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Catalan (https://www.transifex.com/oca/teams/23907/ca/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ca\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr "Connectors"
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr "Tasca de Cua"
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Usuaris"

--- a/connector_job_subscribe/i18n/da.po
+++ b/connector_job_subscribe/i18n/da.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Danish (https://www.transifex.com/oca/teams/23907/da/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: da\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Brugere"

--- a/connector_job_subscribe/i18n/de.po
+++ b/connector_job_subscribe/i18n/de.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr "Connector"
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr "Aufgabe in Warteschlange einreihen"
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Benutzer"

--- a/connector_job_subscribe/i18n/de.po
+++ b/connector_job_subscribe/i18n/de.po
@@ -4,13 +4,14 @@
 # 
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
+# Rudolf Schnapka <rs@techno-flex.de>, 2017
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-05 02:47+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2017-06-24 00:46+0000\n"
+"PO-Revision-Date: 2017-06-24 00:46+0000\n"
+"Last-Translator: Rudolf Schnapka <rs@techno-flex.de>, 2017\n"
 "Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,6 +30,8 @@ msgid ""
 "If this flag is checked and the user is Connector Manager, he will receive "
 "job notifications."
 msgstr ""
+"Wenn dieses Kennzeichen gesetzt ist und der Benutzer ist Verbindungsmanager,"
+" dann wird er Job-Hinweise erhalten."
 
 #. module: connector_job_subscribe
 #: field:res.users,subscribe_job:0

--- a/connector_job_subscribe/i18n/el_GR.po
+++ b/connector_job_subscribe/i18n/el_GR.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Greek (Greece) (https://www.transifex.com/oca/teams/23907/el_GR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: el_GR\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Χρήστες"

--- a/connector_job_subscribe/i18n/es.po
+++ b/connector_job_subscribe/i18n/es.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr "Conectores"
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr "Trabajo de Cola"
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Usuarios"

--- a/connector_job_subscribe/i18n/fi.po
+++ b/connector_job_subscribe/i18n/fi.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Finnish (https://www.transifex.com/oca/teams/23907/fi/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fi\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Käyttäjät"

--- a/connector_job_subscribe/i18n/fr.po
+++ b/connector_job_subscribe/i18n/fr.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr "Connecteurs"
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr "Queue de jobs"
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Utilisateurs"

--- a/connector_job_subscribe/i18n/fr_CH.po
+++ b/connector_job_subscribe/i18n/fr_CH.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: French (Switzerland) (https://www.transifex.com/oca/teams/23907/fr_CH/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fr_CH\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Utilisateurs"

--- a/connector_job_subscribe/i18n/hr.po
+++ b/connector_job_subscribe/i18n/hr.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Croatian (https://www.transifex.com/oca/teams/23907/hr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: hr\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Korisnici"

--- a/connector_job_subscribe/i18n/hr_HR.po
+++ b/connector_job_subscribe/i18n/hr_HR.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Croatian (Croatia) (https://www.transifex.com/oca/teams/23907/hr_HR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: hr_HR\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Korisnici"

--- a/connector_job_subscribe/i18n/hu.po
+++ b/connector_job_subscribe/i18n/hu.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Hungarian (https://www.transifex.com/oca/teams/23907/hu/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: hu\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr "Csatolók"
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr "Sorbanálló feladatok"
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr ""

--- a/connector_job_subscribe/i18n/it.po
+++ b/connector_job_subscribe/i18n/it.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr "Connettori"
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr "Coda Job"
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Utenti"

--- a/connector_job_subscribe/i18n/nl.po
+++ b/connector_job_subscribe/i18n/nl.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Dutch (https://www.transifex.com/oca/teams/23907/nl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: nl\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr "Connectors"
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr "Geplande taken"
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Gebruikers"

--- a/connector_job_subscribe/i18n/pt_BR.po
+++ b/connector_job_subscribe/i18n/pt_BR.po
@@ -4,13 +4,14 @@
 # 
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
+# Rodrigo de Almeida Sottomaior Macedo <rmsolucoeseminformatic4@gmail.com>, 2017
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-05 02:47+0000\n"
-"PO-Revision-Date: 2017-04-05 02:47+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"POT-Creation-Date: 2017-05-01 16:08+0000\n"
+"PO-Revision-Date: 2017-05-01 16:08+0000\n"
+"Last-Translator: Rodrigo de Almeida Sottomaior Macedo <rmsolucoeseminformatic4@gmail.com>, 2017\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/teams/23907/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,11 +30,13 @@ msgid ""
 "If this flag is checked and the user is Connector Manager, he will receive "
 "job notifications."
 msgstr ""
+"Se este sinalizador estiver marcado e o usuário for Connector Manager, ele "
+"receberá notificações de tarefa."
 
 #. module: connector_job_subscribe
 #: field:res.users,subscribe_job:0
 msgid "Jobs Notifications"
-msgstr ""
+msgstr "Notificações de Cargos"
 
 #. module: connector_job_subscribe
 #: model:ir.model,name:connector_job_subscribe.model_queue_job

--- a/connector_job_subscribe/i18n/pt_BR.po
+++ b/connector_job_subscribe/i18n/pt_BR.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/teams/23907/pt_BR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr "Conectores"
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr "Fila de tarefas"
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Usuários"

--- a/connector_job_subscribe/i18n/sl.po
+++ b/connector_job_subscribe/i18n/sl.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Matjaž Mozetič <m.mozetic@matmoz.si>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: Matjaž Mozetič <m.mozetic@matmoz.si>, 2017\n"
+"Language-Team: Slovenian (https://www.transifex.com/oca/teams/23907/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr "Povezovalniki"
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+"Če označeno, bo uporabnik, ki je upravitelj povezovalnikov prejemal "
+"obvestila o delu."
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr "Obvestila o delu"
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr "Delo čakalne vrste"
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Uporabniki"

--- a/connector_job_subscribe/i18n/tr.po
+++ b/connector_job_subscribe/i18n/tr.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Turkish (https://www.transifex.com/oca/teams/23907/tr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: tr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Kullanıcılar"

--- a/connector_job_subscribe/i18n/tr_TR.po
+++ b/connector_job_subscribe/i18n/tr_TR.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Turkish (Turkey) (https://www.transifex.com/oca/teams/23907/tr_TR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: tr_TR\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "Kullanıcılar"

--- a/connector_job_subscribe/i18n/zh_CN.po
+++ b/connector_job_subscribe/i18n/zh_CN.po
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * connector_job_subscribe
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-05 02:47+0000\n"
+"PO-Revision-Date: 2017-04-05 02:47+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Chinese (China) (https://www.transifex.com/oca/teams/23907/zh_CN/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: zh_CN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: connector_job_subscribe
+#: view:res.users:connector_job_subscribe.view_user_connector_form
+msgid "Connectors"
+msgstr "连接器"
+
+#. module: connector_job_subscribe
+#: help:res.users,subscribe_job:0
+msgid ""
+"If this flag is checked and the user is Connector Manager, he will receive "
+"job notifications."
+msgstr ""
+
+#. module: connector_job_subscribe
+#: field:res.users,subscribe_job:0
+msgid "Jobs Notifications"
+msgstr ""
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_queue_job
+msgid "Queue Job"
+msgstr "队列中作业"
+
+#. module: connector_job_subscribe
+#: model:ir.model,name:connector_job_subscribe.model_res_users
+msgid "Users"
+msgstr "用户"

--- a/connector_job_subscribe/models/__init__.py
+++ b/connector_job_subscribe/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import res_users

--- a/connector_job_subscribe/models/res_users.py
+++ b/connector_job_subscribe/models/res_users.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp import fields, models
+
+
+class ResUsers(models.Model):
+    _inherit = 'res.users'
+
+    subscribe_job = fields.Boolean('Jobs Notifications',
+                                   default=True)

--- a/connector_job_subscribe/models/res_users.py
+++ b/connector_job_subscribe/models/res_users.py
@@ -11,4 +11,5 @@ class ResUsers(models.Model):
                                    default=True,
 			           help='If this flag is checked and the'
                                         ' user is Connector Manager, he will'
-                                        ' receive job notifications.')
+                                        ' receive job notifications.',
+				   select=True)

--- a/connector_job_subscribe/models/res_users.py
+++ b/connector_job_subscribe/models/res_users.py
@@ -8,4 +8,7 @@ class ResUsers(models.Model):
     _inherit = 'res.users'
 
     subscribe_job = fields.Boolean('Jobs Notifications',
-                                   default=True)
+                                   default=True,
+			           help='If this flag is checked and the'
+                                        ' user is Connector Manager, he will'
+                                        ' receive job notifications.')

--- a/connector_job_subscribe/models/res_users.py
+++ b/connector_job_subscribe/models/res_users.py
@@ -9,7 +9,7 @@ class ResUsers(models.Model):
 
     subscribe_job = fields.Boolean('Jobs Notifications',
                                    default=True,
-			           help='If this flag is checked and the'
+                                   help='If this flag is checked and the'
                                         ' user is Connector Manager, he will'
                                         ' receive job notifications.',
-				   select=True)
+                                   select=True)

--- a/connector_job_subscribe/queue/__init__.py
+++ b/connector_job_subscribe/queue/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import model

--- a/connector_job_subscribe/queue/model.py
+++ b/connector_job_subscribe/queue/model.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp import api, models
+
+
+class QueueJob(models.Model):
+    _inherit = 'queue.job'
+
+    @api.multi
+    def _get_subscribe_users_domain(self):
+        domain = super(QueueJob, self)._get_subscribe_users_domain()
+        domain.append(('subscribe_job', '=', True))
+        return domain

--- a/connector_job_subscribe/tests/__init__.py
+++ b/connector_job_subscribe/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import test_job_subscribe

--- a/connector_job_subscribe/tests/test_job_subscribe.py
+++ b/connector_job_subscribe/tests/test_job_subscribe.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Cédric Pigeon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import openerp.tests.common as common
+
+from openerp.addons.connector.session import ConnectorSession
+from openerp.addons.connector.queue.job import (
+    Job,
+    OpenERPJobStorage,
+)
+
+
+def task_a(session, model_name):
+    """ Task description
+    """
+
+
+class TestJobSubscribe(common.TransactionCase):
+
+    def setUp(self):
+        super(TestJobSubscribe, self).setUp()
+        grp_connector_manager = self.ref("connector.group_connector_manager")
+        self.other_partner_a = self.env['res.partner'].create(
+            {"name": "My Company a",
+             "is_company": True,
+             "email": "test@tes.ttest",
+             })
+        self.other_user_a = self.env['res.users'].create(
+            {"partner_id": self.other_partner_a.id,
+             "login": "my_login a",
+             "name": "my user",
+             "groups_id": [(4, grp_connector_manager)]
+             })
+        self.other_partner_b = self.env['res.partner'].create(
+            {"name": "My Company b",
+             "is_company": True,
+             "email": "test@tes.ttest",
+             })
+        self.other_user_b = self.env['res.users'].create(
+            {"partner_id": self.other_partner_b.id,
+             "login": "my_login_b",
+             "name": "my user 1",
+             "groups_id": [(4, grp_connector_manager)]
+             })
+
+        self.session = ConnectorSession.from_env(self.env)
+
+    def _create_job(self):
+        test_job = Job(func=task_a)
+        storage = OpenERPJobStorage(self.session)
+        storage.store(test_job)
+        stored = storage.db_record_from_uuid(test_job.uuid)
+        self.assertEqual(len(stored), 1)
+        return stored
+
+    def test_job_subscription(self):
+        """
+            When a job is created, all user of group
+            connector.group_connector_manager are automatically set as
+            follower except if the flag subscribe_job is not set
+        """
+
+        #################################
+        # Test 1: All users are followers
+        #################################
+        stored = self._create_job()
+        stored._subscribe_users()
+        users = self.env['res.users'].search(
+            [('groups_id', '=', self.ref('connector.group_connector_manager'))]
+        )
+        self.assertEqual(len(stored.message_follower_ids), len(users))
+        expected_partners = [u.partner_id for u in users]
+        self.assertSetEqual(set(stored.message_follower_ids),
+                            set(expected_partners))
+        followers_id = [f.id for f in stored.message_follower_ids]
+        self.assertIn(self.other_partner_a.id, followers_id)
+        self.assertIn(self.other_partner_b.id, followers_id)
+
+        ###########################################
+        # Test 2: User b request to not be follower
+        ###########################################
+        self.other_user_b.write({'subscribe_job': False})
+        stored = self._create_job()
+        stored._subscribe_users()
+        users = self.env['res.users'].search(
+            [('groups_id', '=', self.ref('connector.group_connector_manager')),
+             ('subscribe_job', '=', True)]
+        )
+        self.assertEqual(len(stored.message_follower_ids), len(users))
+        expected_partners = [u.partner_id for u in users]
+        self.assertSetEqual(set(stored.message_follower_ids),
+                            set(expected_partners))
+        followers_id = [f.id for f in stored.message_follower_ids]
+        self.assertIn(self.other_partner_a.id, followers_id)
+        self.assertNotIn(self.other_partner_b.id, followers_id)

--- a/connector_job_subscribe/views/res_users_view.xml
+++ b/connector_job_subscribe/views/res_users_view.xml
@@ -2,7 +2,7 @@
 
 <openerp>
     <data noupdate="0">
-        <record id="view_puser_connector_form" model="ir.ui.view">
+        <record id="view_user_connector_form" model="ir.ui.view">
             <field name="name">res.user.connector.form</field>
             <field name="model">res.users</field>
             <field name="inherit_id" ref="base.view_users_form" />

--- a/connector_job_subscribe/views/res_users_view.xml
+++ b/connector_job_subscribe/views/res_users_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<openerp>
+    <data noupdate="0">
+        <record id="view_puser_connector_form" model="ir.ui.view">
+            <field name="name">res.user.connector.form</field>
+            <field name="model">res.users</field>
+            <field name="inherit_id" ref="base.view_users_form" />
+            <field name="arch" type="xml">
+                <xpath expr="/form/sheet/notebook" position="inside">
+                    <page string="Connectors" name="connector">
+                        <group>
+                            <field name="subscribe_job"/>
+                        </group>
+                    </page>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/setup/connector_job_subscribe/odoo_addons/__init__.py
+++ b/setup/connector_job_subscribe/odoo_addons/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/connector_job_subscribe/odoo_addons/connector_job_subscribe
+++ b/setup/connector_job_subscribe/odoo_addons/connector_job_subscribe
@@ -1,0 +1,1 @@
+../../../connector_job_subscribe

--- a/setup/connector_job_subscribe/setup.py
+++ b/setup/connector_job_subscribe/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
In our proxy setup we've foreseen potential cases where the proxy would answer a jobrunner with a 503 HTTP error code in case the chosen Odoo backend server would be too busy for answering the jobrunners call while assigning a job. 

We would like to propose this change to take into account HTTP error response codes (400 through 600) and just raise when this happens. This will cause the same behaviour as when having a timeout on our call.