### PR TITLE
[REM] Remove mail thread from the job queue creation.

### DIFF
--- a/connector/queue/job.py
+++ b/connector/queue/job.py
@@ -263,7 +263,10 @@ class OpenERPJobStorage(JobStorage):
                                   job_.args,
                                   job_.kwargs))
 
-            self.job_model.sudo().create(vals)
+            self.job_model.with_context(
+                mail_create_nosubscribe=True,
+                mail_create_nolog=True,
+                mail_notrack=True).sudo().create(vals)
 
     def load(self, job_uuid):
         """ Read a job from the Database"""


### PR DESCRIPTION
Since the connector will add the follower automatically when the job fails this does not do much in the first place.

The Administrator would be a folower on create, which is not needed anyway. So this should not break our normal messaging usage.