### PR TITLE
[FIX] Also set hostname on enqueued jobs

### DIFF
--- a/connector/queue/job.py
+++ b/connector/queue/job.py
@@ -612,6 +612,7 @@ class Job(object):
         self.date_enqueued = datetime.now()
         self.date_started = None
         self.worker_uuid = worker.uuid
+        self.worker_hostname = gethostname()
 
     def set_started(self):
         self.state = STARTED


### PR DESCRIPTION
The Levi9 script expects this, so if we leave the hostname empty, any enqueued
job will not be reset to pending. To make things worse, the number of available
scaleout channels is only updated when a job is enqueued so if we restart Odoo
and there are already three enqueued jobs (the arbitrary, default number of channels),
not a single job will be started.